### PR TITLE
Add `tobari flags --fix` option

### DIFF
--- a/cmd/tobari/main.go
+++ b/cmd/tobari/main.go
@@ -23,8 +23,9 @@ func run(ctx context.Context, args []string) error {
 	}
 
 	tobariBinPath := args[0]
-	if len(args) == 2 && args[1] == "flags" {
-		out, err := flags.Run(ctx, tobariBinPath)
+	if len(args) >= 2 && args[1] == "flags" {
+		fix := len(args) == 3 && args[2] == "--fix"
+		out, err := flags.Run(ctx, tobariBinPath, fix)
 		if err != nil {
 			return err
 		}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goccy/tobari/internal/overlay"
 )
 
-func Run(ctx context.Context, tobariBinPath string) (string, error) {
+func Run(ctx context.Context, tobariBinPath string, fix bool) (string, error) {
 	path, err := exec.LookPath(tobariBinPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to find tobari binary path from %s: %w", tobariBinPath, err)
@@ -22,7 +22,7 @@ func Run(ctx context.Context, tobariBinPath string) (string, error) {
 		}
 		path = p
 	}
-	f, err := overlay.Create(ctx)
+	f, err := overlay.Create(ctx, fix)
 	if err != nil {
 		return "", fmt.Errorf("failed to create overlay file: %w", err)
 	}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -19,8 +19,8 @@ import (
 	"time"
 )
 
-func Create(ctx context.Context) (string, error) {
-	overlay, err := createOverlay(ctx, []*Definition{
+func Create(ctx context.Context, fix bool) (string, error) {
+	overlay, err := createOverlay(ctx, fix, []*Definition{
 		{
 			PkgPath: "runtime",
 			Functions: []*Function{
@@ -69,12 +69,17 @@ type Overlay struct {
 //go:embed templates/*.tmpl
 var tmpls embed.FS
 
-func createOverlay(ctx context.Context, defs []*Definition) (*Overlay, error) {
+func createOverlay(ctx context.Context, fix bool, defs []*Definition) (*Overlay, error) {
 	root, err := OverlayRootDir(ctx)
 	if err != nil {
 		return nil, err
 	}
-	id := fmt.Sprint(time.Now().UnixNano())
+	var id string
+	if fix {
+		id = "fix"
+	} else {
+		id = fmt.Sprint(time.Now().UnixNano())
+	}
 	if err := os.MkdirAll(filepath.Join(root, id), 0o755); err != nil {
 		return nil, err
 	}

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOverlay(t *testing.T) {
-	o, err := overlay.Create(t.Context())
+	o, err := overlay.Create(t.Context(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,5 +23,55 @@ func TestOverlay(t *testing.T) {
 	}
 	if len(v.Replace) != 6 {
 		t.Fatalf("unexpected replace contents: got: %v", len(v.Replace))
+	}
+}
+
+func TestOverlayWithoutFix(t *testing.T) {
+	// When fix=false, each call should generate a different overlay
+	o1, err := overlay.Create(t.Context(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f1, err := os.ReadFile(o1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o2, err := overlay.Create(t.Context(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := os.ReadFile(o2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(f1) == string(f2) {
+		t.Fatal("expected different overlay content for fix=false, but got the same")
+	}
+}
+
+func TestOverlayWithFix(t *testing.T) {
+	// When fix=true, each call should generate the same overlay
+	o1, err := overlay.Create(t.Context(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f1, err := os.ReadFile(o1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o2, err := overlay.Create(t.Context(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := os.ReadFile(o2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(f1) != string(f2) {
+		t.Fatal("expected same overlay content for fix=true, but got different")
 	}
 }


### PR DESCRIPTION
Add `--fix` option to tobari flags command

When --fix is specified, use a fixed ID for overlay files instead of timestamp-based ID. This enables Go build cache to work efficiently by generating identical overlay content across multiple runs.
