### PR TITLE
Use hash-based overlay directory for deterministic builds

### DIFF
--- a/cmd/tobari/main.go
+++ b/cmd/tobari/main.go
@@ -24,8 +24,7 @@ func run(ctx context.Context, args []string) error {
 
 	tobariBinPath := args[0]
 	if len(args) >= 2 && args[1] == "flags" {
-		fix := len(args) == 3 && args[2] == "--fix"
-		out, err := flags.Run(ctx, tobariBinPath, fix)
+		out, err := flags.Run(ctx, tobariBinPath)
 		if err != nil {
 			return err
 		}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goccy/tobari/internal/overlay"
 )
 
-func Run(ctx context.Context, tobariBinPath string, fix bool) (string, error) {
+func Run(ctx context.Context, tobariBinPath string) (string, error) {
 	path, err := exec.LookPath(tobariBinPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to find tobari binary path from %s: %w", tobariBinPath, err)
@@ -22,13 +22,13 @@ func Run(ctx context.Context, tobariBinPath string, fix bool) (string, error) {
 		}
 		path = p
 	}
-	f, err := overlay.Create(ctx, fix)
+	overlayPath, err := overlay.Create(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to create overlay file: %w", err)
 	}
 	return strings.Join([]string{
 		"-cover",
-		"-overlay=" + f,
+		"-overlay=" + overlayPath,
 		"-toolexec=" + path,
 	}, " "), nil
 }

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -3,7 +3,9 @@ package overlay
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"go/ast"
@@ -14,13 +16,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
-	"time"
 )
 
-func Create(ctx context.Context, fix bool) (string, error) {
-	overlay, err := createOverlay(ctx, fix, []*Definition{
+func Create(ctx context.Context) (string, error) {
+	overlay, err := createOverlay(ctx, []*Definition{
 		{
 			PkgPath: "runtime",
 			Functions: []*Function{
@@ -69,35 +71,36 @@ type Overlay struct {
 //go:embed templates/*.tmpl
 var tmpls embed.FS
 
-func createOverlay(ctx context.Context, fix bool, defs []*Definition) (*Overlay, error) {
+func createOverlay(ctx context.Context, defs []*Definition) (*Overlay, error) {
 	root, err := OverlayRootDir(ctx)
 	if err != nil {
 		return nil, err
 	}
-	var id string
-	if fix {
-		id = "fix"
-	} else {
-		id = fmt.Sprint(time.Now().UnixNano())
-	}
-	if err := os.MkdirAll(filepath.Join(root, id), 0o755); err != nil {
-		return nil, err
-	}
 
-	overlayMap := make(map[string]string)
+	// Use fixed suffix "tobari" for function names to make hash deterministic
+	const funcSuffix = "tobari"
+
+	// First pass: collect all rendered content to compute hash
+	type renderedFile struct {
+		pkgPath  string
+		fileName string
+		content  []byte
+		isNew    bool // true for template-generated files, false for modified files
+		origPath string
+	}
+	var renderedFiles []renderedFile
+
 	for _, def := range defs {
-		if err := os.MkdirAll(filepath.Join(root, id, def.PkgPath), 0o755); err != nil {
-			return nil, err
-		}
-		pkgPath, err := pkgPath(ctx, def.PkgPath)
+		pkgPathStr, err := pkgPath(ctx, def.PkgPath)
 		if err != nil {
 			return nil, err
 		}
-		pkgFiles, err := pkgGoFiles(ctx, pkgPath)
+		pkgFiles, err := pkgGoFiles(ctx, pkgPathStr)
 		if err != nil {
 			return nil, err
 		}
 		pkgScopedReplacedNameMap := make(map[string]string)
+
 		for _, pkgFile := range pkgFiles {
 			src, err := os.ReadFile(pkgFile)
 			if err != nil {
@@ -120,7 +123,7 @@ func createOverlay(ctx context.Context, fix bool, defs []*Definition) (*Overlay,
 				if fn == nil {
 					continue
 				}
-				newName := fn.Name + "_" + id
+				newName := fn.Name + "_" + funcSuffix
 				funcDecl.Name = &ast.Ident{Name: newName}
 				fileScopedReplacedNameMap[fn.Name] = newName
 				pkgScopedReplacedNameMap[fn.Name] = newName
@@ -130,23 +133,59 @@ func createOverlay(ctx context.Context, fix bool, defs []*Definition) (*Overlay,
 				if err := format.Node(&buf, fset, file); err != nil {
 					return nil, fmt.Errorf("failed to format AST: %w", err)
 				}
-				tmpFile := filepath.Join(root, id, def.PkgPath, filepath.Base(pkgFile))
-				if err := os.WriteFile(tmpFile, buf.Bytes(), 0o600); err != nil {
-					return nil, err
-				}
-				overlayMap[pkgFile] = tmpFile
+				renderedFiles = append(renderedFiles, renderedFile{
+					pkgPath:  def.PkgPath,
+					fileName: filepath.Base(pkgFile),
+					content:  buf.Bytes(),
+					isNew:    false,
+					origPath: pkgFile,
+				})
 			}
 		}
+
 		b, err := evalTemplate(def.Template, pkgScopedReplacedNameMap)
 		if err != nil {
 			return nil, err
 		}
-		tmpFile := filepath.Join(root, id, def.PkgPath, id+".go")
-		if err := os.WriteFile(tmpFile, b, 0o600); err != nil {
+		renderedFiles = append(renderedFiles, renderedFile{
+			pkgPath:  def.PkgPath,
+			fileName: "tobari.go",
+			content:  b,
+			isNew:    true,
+			origPath: filepath.Join(pkgPathStr, "tobari.go"),
+		})
+	}
+
+	// Compute hash from all rendered content
+	h := sha256.New()
+	// Sort by origPath to ensure deterministic ordering
+	sort.Slice(renderedFiles, func(i, j int) bool {
+		return renderedFiles[i].origPath < renderedFiles[j].origPath
+	})
+	for _, rf := range renderedFiles {
+		h.Write([]byte(rf.origPath))
+		h.Write(rf.content)
+	}
+	id := hex.EncodeToString(h.Sum(nil))[:16]
+
+	// Create directories and write files
+	if err := os.MkdirAll(filepath.Join(root, id), 0o755); err != nil {
+		return nil, err
+	}
+
+	overlayMap := make(map[string]string)
+	for _, rf := range renderedFiles {
+		dirPath := filepath.Join(root, id, rf.pkgPath)
+		if err := os.MkdirAll(dirPath, 0o755); err != nil {
 			return nil, err
 		}
-		overlayMap[filepath.Join(pkgPath, id+".go")] = tmpFile
+		tmpFile := filepath.Join(dirPath, rf.fileName)
+		if err := os.WriteFile(tmpFile, rf.content, 0o600); err != nil {
+			return nil, err
+		}
+		overlayMap[rf.origPath] = tmpFile
 	}
+
 	path, _ := OverlayPath(ctx)
 	return &Overlay{Replace: overlayMap, path: path}, nil
 }
@@ -269,4 +308,24 @@ func goVersion(ctx context.Context) (string, error) {
 		return string(out), fmt.Errorf("failed to get GOROOT: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// GetReplace reads overlay.json and returns the Replace map.
+func GetReplace(ctx context.Context) (map[string]string, error) {
+	path, err := OverlayPath(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var overlay Overlay
+	if err := json.Unmarshal(data, &overlay); err != nil {
+		return nil, err
+	}
+
+	return overlay.Replace, nil
 }

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOverlay(t *testing.T) {
-	o, err := overlay.Create(t.Context(), false)
+	o, err := overlay.Create(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,14 +21,17 @@ func TestOverlay(t *testing.T) {
 	if err := json.Unmarshal(f, &v); err != nil {
 		t.Fatal(err)
 	}
+	// 6 files: runtime/covercounter.go, runtime/tobari.go, testing/testing.go, testing/tobari.go,
+	// testing/internal/testdeps/deps.go, testing/internal/testdeps/tobari.go
 	if len(v.Replace) != 6 {
 		t.Fatalf("unexpected replace contents: got: %v", len(v.Replace))
 	}
 }
 
-func TestOverlayWithoutFix(t *testing.T) {
-	// When fix=false, each call should generate a different overlay
-	o1, err := overlay.Create(t.Context(), false)
+func TestOverlayDeterministic(t *testing.T) {
+	// With the new hash-based approach, each call should generate the same overlay
+	// because the content is deterministic (based on template rendering results)
+	o1, err := overlay.Create(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,32 +40,7 @@ func TestOverlayWithoutFix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	o2, err := overlay.Create(t.Context(), false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f2, err := os.ReadFile(o2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(f1) == string(f2) {
-		t.Fatal("expected different overlay content for fix=false, but got the same")
-	}
-}
-
-func TestOverlayWithFix(t *testing.T) {
-	// When fix=true, each call should generate the same overlay
-	o1, err := overlay.Create(t.Context(), true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f1, err := os.ReadFile(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	o2, err := overlay.Create(t.Context(), true)
+	o2, err := overlay.Create(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,6 +50,6 @@ func TestOverlayWithFix(t *testing.T) {
 	}
 
 	if string(f1) != string(f2) {
-		t.Fatal("expected same overlay content for fix=true, but got different")
+		t.Fatal("expected same overlay content for deterministic hash-based approach, but got different")
 	}
 }

--- a/internal/tool/compile.go
+++ b/internal/tool/compile.go
@@ -8,10 +8,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/goccy/tobari/internal/overlay"
 )
 
 func handleCompile(ctx context.Context, toolPath string, args []string) error {
-	args, err := filterCoveragecfg(args)
+	// Replace file paths and add new files based on overlay Replace map.
+	// This handles the case where Go's overlay mechanism doesn't work
+	// (e.g., when toolchain is installed in GOMODCACHE).
+	replace, err := overlay.GetReplace(ctx)
+	if err == nil {
+		args = applyOverlayReplacements(args, replace)
+	}
+
+	args, err = filterCoveragecfg(args)
 	if err != nil {
 		return err
 	}
@@ -85,6 +95,76 @@ SEARCH_TOBARI_PKG_END:
 		return fmt.Errorf("failed to update importcfg: %w", err)
 	}
 	return nil
+}
+
+// applyOverlayReplacements replaces file paths and adds new files based on overlay Replace map.
+// This is essential for toolchain directive support where Go is installed in GOMODCACHE
+// and the standard overlay mechanism may not work correctly.
+func applyOverlayReplacements(args []string, replace map[string]string) []string {
+	// Build a set of existing file paths in args for quick lookup
+	existingFiles := make(map[string]bool)
+	for _, arg := range args {
+		if filepath.Ext(arg) == ".go" {
+			existingFiles[arg] = true
+			// Also add the absolute path
+			if abs, err := filepath.Abs(arg); err == nil {
+				existingFiles[abs] = true
+			}
+		}
+	}
+
+	// Get the package name from -p flag
+	pkgName := getPkgNameFromArgs(args)
+
+	// Collect new files to add
+	var newFiles []string
+	for origPath, newPath := range replace {
+		// Check if this is a new file (tobari.go) for the current package
+		if strings.HasSuffix(origPath, "/tobari.go") {
+			// Extract package name from origPath
+			// e.g., /usr/local/go/src/runtime/tobari.go -> runtime
+			dir := filepath.Dir(origPath)
+			pkgFromPath := filepath.Base(dir)
+
+			// Check if this tobari.go belongs to the current package
+			if pkgFromPath == pkgName {
+				// Only add if not already in args (overlay might have already added it)
+				if !existingFiles[newPath] {
+					newFiles = append(newFiles, newPath)
+				}
+			}
+		}
+	}
+
+	// Replace existing file paths in args
+	for i, arg := range args {
+		if filepath.Ext(arg) != ".go" {
+			continue
+		}
+		// Try to match the arg with an original path in replace map
+		absArg, err := filepath.Abs(arg)
+		if err != nil {
+			continue
+		}
+		if newPath, ok := replace[absArg]; ok {
+			// Replace with the overlay path if not already replaced
+			if args[i] != newPath {
+				args[i] = newPath
+			}
+		}
+	}
+
+	// Add new files to the compile arguments
+	return append(args, newFiles...)
+}
+
+func getPkgNameFromArgs(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-p" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
 }
 
 func filterCoveragecfg(args []string) ([]string, error) {

--- a/internal/tool/handler.go
+++ b/internal/tool/handler.go
@@ -2,15 +2,27 @@ package tool
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/goccy/tobari/internal/overlay"
 )
 
 func Handle(ctx context.Context, args []string) error {
 	toolPath := args[1]
 	toolArgs := args[2:]
+
+	// Handle -V=full flag to isolate build cache
+	if slices.Contains(toolArgs, "-V=full") {
+		return handleVersionFull(ctx, toolPath, toolArgs)
+	}
 
 	toolName := filepath.Base(toolPath)
 	switch toolName {
@@ -49,4 +61,34 @@ func runCommand(bin string, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+}
+
+func handleVersionFull(ctx context.Context, toolPath string, args []string) error {
+	// Execute the original tool to get version info
+	out, err := exec.CommandContext(ctx, toolPath, args...).Output()
+	if err != nil {
+		// If the tool fails, just run it normally
+		runCommand(toolPath, args)
+		return nil
+	}
+
+	// Get the Replace map from overlay.json
+	replace, err := overlay.GetReplace(ctx)
+	if err != nil {
+		// If overlay.json doesn't exist, just output the original version
+		fmt.Print(string(out))
+		return nil
+	}
+
+	// Compute hash from the Replace map
+	h := sha256.New()
+	if err := json.NewEncoder(h).Encode(replace); err != nil {
+		fmt.Print(string(out))
+		return nil
+	}
+	hash := hex.EncodeToString(h.Sum(nil))[:16]
+
+	// Output version with tobari hash suffix
+	fmt.Printf("%s tobari:%s\n", strings.TrimSpace(string(out)), hash)
+	return nil
 }

--- a/testdata/toolchain/expected.cover
+++ b/testdata/toolchain/expected.cover
@@ -1,0 +1,3 @@
+mode: set
+testdata/toolchain/main.go:18.24,18.48 1 1
+testdata/toolchain/main.go:37.72,39.3 1 1

--- a/testdata/toolchain/go.mod
+++ b/testdata/toolchain/go.mod
@@ -1,0 +1,9 @@
+module example.com/toolchain-test
+
+go 1.24.0
+
+toolchain go1.24.7
+
+require github.com/goccy/tobari v0.0.0
+
+replace github.com/goccy/tobari => ../..

--- a/testdata/toolchain/go.mod
+++ b/testdata/toolchain/go.mod
@@ -2,7 +2,7 @@ module example.com/toolchain-test
 
 go 1.24.0
 
-toolchain go1.24.7
+toolchain go1.25.1
 
 require github.com/goccy/tobari v0.0.0
 

--- a/testdata/toolchain/main.go
+++ b/testdata/toolchain/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/goccy/tobari"
+)
+
+func coverageMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get("X-GO-COVERAGE"); v != "" {
+			tobari.Cover(func() { next.ServeHTTP(w, r) })
+		} else {
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+func run(ctx context.Context) error {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/coverstart", func(w http.ResponseWriter, req *http.Request) {
+		tobari.ClearCounters()
+		fmt.Fprintf(w, "started")
+	})
+
+	mux.HandleFunc("/coverend", func(w http.ResponseWriter, req *http.Request) {
+		tobari.WriteCoverProfile(tobari.SetMode, w)
+	})
+
+	mux.HandleFunc("/foo", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "foo")
+	})
+
+	srv := httptest.NewServer(coverageMiddleware(mux))
+	defer srv.Close()
+
+	cli := new(http.Client)
+
+	// start coverage
+	if err := func() error {
+		req, err := http.NewRequest("GET", srv.URL+"/coverstart", nil)
+		if err != nil {
+			return err
+		}
+		resp, err := cli.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	// access foo endpoint with coverage header
+	if err := func() error {
+		req, err := http.NewRequest("GET", srv.URL+"/foo", nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Add("X-GO-COVERAGE", "true")
+		resp, err := cli.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	// end coverage
+	if err := func() error {
+		req, err := http.NewRequest("GET", srv.URL+"/coverend", nil)
+		if err != nil {
+			return err
+		}
+		resp, err := cli.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile("toolchain.cover", b, 0o600)
+	}(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -141,3 +141,78 @@ func TestZeroConfiguration(t *testing.T) {
 		t.Log(string(out))
 	}
 }
+
+func TestToolchain(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari-test")
+	defer func() {
+		_ = os.RemoveAll(tobariBin)
+	}()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := exec.CommandContext(
+		ctx,
+		"go",
+		"build",
+		"-o",
+		tobariBin,
+		"./cmd/tobari",
+	).CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+
+	dir := filepath.Join("testdata", "toolchain")
+
+	// Run tobari flags in the toolchain directory
+	flagsCmd := exec.CommandContext(ctx, tobariBin, "flags")
+	flagsCmd.Dir = dir
+	tobariFlagsOut, err := flagsCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run tobari flags: %s: %v", string(tobariFlagsOut), err)
+	}
+	tobariFlags := strings.TrimSpace(string(tobariFlagsOut))
+
+	// Run the test with toolchain specified go.mod
+	args := append(
+		[]string{"run"},
+		strings.Split(tobariFlags, " ")...,
+	)
+	args = append(args, "main.go")
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to run test: %s: %v", string(out), err)
+	} else {
+		t.Log(string(out))
+	}
+
+	// Check the generated cover file
+	coverFile := filepath.Join(dir, "toolchain.cover")
+	f, err := os.ReadFile(coverFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, line := range strings.Split(string(f), "\n") {
+		if strings.HasPrefix(line, "/") {
+			out = append(out, strings.TrimPrefix(line, cwd+"/"))
+		} else {
+			out = append(out, line)
+		}
+	}
+	got := strings.Join(out, "\n")
+	expected, err := os.ReadFile(filepath.Join(dir, "expected.cover"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(got, string(expected)); diff != "" {
+		t.Errorf("(-got, +want)\n%s", diff)
+	}
+
+	// Cleanup generated cover file
+	_ = os.Remove(coverFile)
+}


### PR DESCRIPTION
This change improves the overlay mechanism to use content-based hashing
instead of timestamps, making builds more deterministic and eliminating
the need for the --fix option.

Key changes:
- Use SHA256 hash of rendered template content as overlay directory ID
- Add -V=full handling in toolexec to isolate build cache by appending
  a hash to the version output
- Add GetReplace() function to read overlay.json Replace map
- Remove --fix option from tobari flags command (no longer needed)
- Add TestToolchain test with testdata/toolchain directory

The overlay now generates consistent directory names based on content,
so the same source code always produces the same overlay. This enables
proper build caching while still allowing overlay modifications to
trigger rebuilds via the -V=full version hash mechanism.
