### PR TITLE
Add CLI with flag package for option parsing

### DIFF
--- a/cmd/tobari/main.go
+++ b/cmd/tobari/main.go
@@ -5,34 +5,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/goccy/tobari/internal/flags"
-	"github.com/goccy/tobari/internal/tool"
+	"github.com/goccy/tobari/internal/cli"
 )
 
 func main() {
 	ctx := context.Background()
-	if err := run(ctx, os.Args); err != nil {
+	c := cli.New()
+	if err := c.Run(ctx, os.Args); err != nil {
 		fmt.Fprint(os.Stderr, err)
 		os.Exit(1)
 	}
-}
-
-func run(ctx context.Context, args []string) error {
-	if len(args) < 2 {
-		return nil
-	}
-
-	tobariBinPath := args[0]
-	if len(args) >= 2 && args[1] == "flags" {
-		out, err := flags.Run(ctx, tobariBinPath)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprint(os.Stdout, string(out)); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	return tool.Handle(ctx, args)
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/goccy/tobari/internal/tool"
+)
+
+// CLI handles command-line interface processing
+type CLI struct {
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// New creates a new CLI instance
+func New() *CLI {
+	return &CLI{
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+}
+
+// Run processes command-line arguments
+func (c *CLI) Run(ctx context.Context, args []string) error {
+	if len(args) == 1 {
+		return c.showHelp()
+	}
+
+	tobariBinPath := args[0]
+	arg1 := args[1]
+
+	// Check if this is a toolexec call
+	// toolexec passes Go tool's absolute path as args[1]
+	if isToolexecCall(arg1) {
+		return tool.Handle(ctx, args)
+	}
+
+	// Handle flags (starts with "-")
+	if len(arg1) > 0 && arg1[0] == '-' {
+		return c.handleFlags(ctx, args[1:])
+	}
+
+	// Handle subcommands
+	return c.handleSubcommand(ctx, tobariBinPath, arg1)
+}
+
+// isToolexecCall determines if the argument is a toolexec invocation
+func isToolexecCall(arg string) bool {
+	// toolexec passes Go tools as absolute paths
+	// e.g., /usr/local/go/pkg/tool/darwin_arm64/compile
+	return filepath.IsAbs(arg)
+}
+
+// handleFlags processes top-level flags
+func (c *CLI) handleFlags(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("tobari", flag.ContinueOnError)
+	fs.SetOutput(c.stderr)
+
+	showVersion := fs.Bool("v", false, "show version")
+	showHelp := fs.Bool("h", false, "show help")
+
+	// Also support --version and --help (flag treats -- as -)
+	fs.BoolVar(showVersion, "version", false, "show version")
+	fs.BoolVar(showHelp, "help", false, "show help")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *showVersion {
+		return c.showVersion()
+	}
+	if *showHelp {
+		return c.showHelp()
+	}
+
+	return c.showHelp()
+}
+
+// handleSubcommand processes subcommands
+func (c *CLI) handleSubcommand(ctx context.Context, tobariBinPath, cmd string) error {
+	switch cmd {
+	case "flags":
+		return c.runFlagsCmd(ctx, tobariBinPath)
+	case "version":
+		return c.showVersion()
+	case "help":
+		return c.showHelp()
+	default:
+		return fmt.Errorf("unknown command: %s\nRun 'tobari help' for usage", cmd)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestIsToolexecCall(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      string
+		expected bool
+	}{
+		{"absolute path (compile)", "/usr/local/go/pkg/tool/darwin_arm64/compile", true},
+		{"absolute path (link)", "/usr/local/go/pkg/tool/darwin_arm64/link", true},
+		{"absolute path (vet)", "/opt/go/pkg/tool/linux_amd64/vet", true},
+		{"subcommand flags", "flags", false},
+		{"subcommand version", "version", false},
+		{"subcommand help", "help", false},
+		{"flag -v", "-v", false},
+		{"flag --version", "--version", false},
+		{"flag -h", "-h", false},
+		{"flag --help", "--help", false},
+		{"relative path", "./some/path", false},
+		{"relative path with dots", "../bin/tool", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isToolexecCall(tt.arg)
+			if got != tt.expected {
+				t.Errorf("isToolexecCall(%q) = %v, want %v", tt.arg, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCLI_ShowVersion(t *testing.T) {
+	var stdout bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &bytes.Buffer{}}
+
+	err := c.showVersion()
+	if err != nil {
+		t.Fatalf("showVersion() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "tobari version") {
+		t.Errorf("showVersion() output = %q, want to contain 'tobari version'", output)
+	}
+}
+
+func TestCLI_ShowHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &bytes.Buffer{}}
+
+	err := c.showHelp()
+	if err != nil {
+		t.Fatalf("showHelp() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("showHelp() output = %q, want to contain 'Usage:'", output)
+	}
+	if !strings.Contains(output, "Commands:") {
+		t.Errorf("showHelp() output = %q, want to contain 'Commands:'", output)
+	}
+}
+
+func TestCLI_Run(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantContain string
+		wantErr     bool
+	}{
+		{
+			name:        "no args shows help",
+			args:        []string{"tobari"},
+			wantContain: "Usage:",
+		},
+		{
+			name:        "version subcommand",
+			args:        []string{"tobari", "version"},
+			wantContain: "tobari version",
+		},
+		{
+			name:        "help subcommand",
+			args:        []string{"tobari", "help"},
+			wantContain: "Usage:",
+		},
+		{
+			name:        "-v flag",
+			args:        []string{"tobari", "-v"},
+			wantContain: "tobari version",
+		},
+		{
+			name:        "--version flag",
+			args:        []string{"tobari", "--version"},
+			wantContain: "tobari version",
+		},
+		{
+			name:        "-h flag",
+			args:        []string{"tobari", "-h"},
+			wantContain: "Usage:",
+		},
+		{
+			name:        "--help flag",
+			args:        []string{"tobari", "--help"},
+			wantContain: "Usage:",
+		},
+		{
+			name:    "unknown command",
+			args:    []string{"tobari", "unknown"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			c := &CLI{stdout: &stdout, stderr: &stderr}
+			ctx := context.Background()
+
+			err := c.Run(ctx, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !strings.Contains(stdout.String(), tt.wantContain) {
+				t.Errorf("Run() output = %q, want to contain %q", stdout.String(), tt.wantContain)
+			}
+		})
+	}
+}

--- a/internal/cli/flags_cmd.go
+++ b/internal/cli/flags_cmd.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goccy/tobari/internal/flags"
+)
+
+func (c *CLI) runFlagsCmd(ctx context.Context, tobariBinPath string) error {
+	out, err := flags.Run(ctx, tobariBinPath)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(c.stdout, out)
+	return nil
+}

--- a/internal/cli/flags_cmd.go
+++ b/internal/cli/flags_cmd.go
@@ -13,6 +13,6 @@ func (c *CLI) runFlagsCmd(ctx context.Context, tobariBinPath string) error {
 		return err
 	}
 
-	fmt.Fprint(c.stdout, out)
-	return nil
+	_, err = fmt.Fprint(c.stdout, out)
+	return err
 }

--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -29,6 +29,6 @@ For more information, visit: https://github.com/goccy/tobari
 `
 
 func (c *CLI) showHelp() error {
-	fmt.Fprint(c.stdout, helpText)
-	return nil
+	_, err := fmt.Fprint(c.stdout, helpText)
+	return err
 }

--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -1,0 +1,34 @@
+package cli
+
+import "fmt"
+
+const helpText = `tobari - Go scoped coverage measurement tool
+
+Usage:
+    tobari <command>
+    tobari [flags]
+
+Commands:
+    flags       Output flags for go build/test with coverage
+    version     Show version information
+    help        Show this help message
+
+Flags:
+    -v, --version    Show version information
+    -h, --help       Show this help message
+
+Examples:
+    # Get flags for go build
+    go build $(tobari flags) ./...
+
+    # Show version
+    tobari version
+    tobari -v
+
+For more information, visit: https://github.com/goccy/tobari
+`
+
+func (c *CLI) showHelp() error {
+	fmt.Fprint(c.stdout, helpText)
+	return nil
+}

--- a/internal/cli/version_cmd.go
+++ b/internal/cli/version_cmd.go
@@ -15,6 +15,6 @@ func (c *CLI) showVersion() error {
 		}
 	}
 
-	fmt.Fprintf(c.stdout, "tobari version %s\n", ver)
-	return nil
+	_, err := fmt.Fprintf(c.stdout, "tobari version %s\n", ver)
+	return err
 }

--- a/internal/cli/version_cmd.go
+++ b/internal/cli/version_cmd.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
+
+func (c *CLI) showVersion() error {
+	ver := "(devel)"
+
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		if v := buildInfo.Main.Version; v != "" && strings.HasPrefix(v, "v") {
+			ver = v
+		}
+	}
+
+	fmt.Fprintf(c.stdout, "tobari version %s\n", ver)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `internal/cli` package for command-line argument parsing using Go's standard `flag` package
- Implement subcommands: `flags`, `version`, `help`
- Support flags: `-v`/`--version`, `-h`/`--help`
- Show help when tobari is run without arguments
- Maintain backward compatibility with toolexec mode

## Test plan
- [x] `tobari` (no args) → shows help
- [x] `tobari help` / `-h` / `--help` → shows help
- [x] `tobari version` / `-v` / `--version` → shows version
- [x] `tobari flags` → outputs build flags
- [x] `go build -cover -toolexec=tobari` → works as before
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)