### PR TITLE
Fix fingerprint mismatch by using consistent overlay directory path

### DIFF
--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -248,7 +248,9 @@ func RenderPackage(def *Definition, sourceFiles []string) (*PackageOverlay, erro
 	}
 	id := hex.EncodeToString(h.Sum(nil))[:16]
 
-	// Write to deterministic directory
+	// Write to deterministic directory using atomic writes.
+	// Since multiple builds may run concurrently, we write to a temp file
+	// and rename to avoid partial reads.
 	dir := filepath.Join(utils.OverlayDir(), id)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create overlay dir: %w", err)
@@ -257,7 +259,7 @@ func RenderPackage(def *Definition, sourceFiles []string) (*PackageOverlay, erro
 	replace := make(map[string]string)
 	for _, f := range rendered {
 		path := filepath.Join(dir, f.basename)
-		if err := os.WriteFile(path, f.content, 0o600); err != nil {
+		if err := atomicWriteFile(path, f.content); err != nil {
 			return nil, fmt.Errorf("failed to write %s: %w", f.basename, err)
 		}
 		if f.origPath != "" {
@@ -292,6 +294,36 @@ func evalTemplate(path string, replacedNameMap map[string]string) ([]byte, error
 		return nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 	return b.Bytes(), nil
+}
+
+// atomicWriteFile writes content to path atomically using a temp file and rename.
+// If the file already exists with the same content, it's a no-op.
+func atomicWriteFile(path string, content []byte) error {
+	// Check if file already exists with correct content
+	existing, err := os.ReadFile(path)
+	if err == nil && bytes.Equal(existing, content) {
+		return nil
+	}
+
+	// Write to temp file in the same directory (for same-filesystem rename)
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // Clean up on error
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	// Atomic rename
+	return os.Rename(tmpPath, path)
 }
 
 func matchedFunc(def *Definition, decl *ast.FuncDecl) *Function {

--- a/internal/tool/app.go
+++ b/internal/tool/app.go
@@ -112,15 +112,5 @@ func main() {}
 }
 
 func appPath(ver *version.Version) string {
-	goVer, err := utils.GoVersion()
-	if err != nil {
-		goVer = runtime.Version()
-	}
-	return filepath.Join(
-		utils.TobariTempDir(),
-		goVer,
-		runtime.GOARCH,
-		ver.ID(),
-		fmt.Sprint(os.Getpid()),
-	)
+	return utils.AppPath()
 }

--- a/internal/utils/go.go
+++ b/internal/utils/go.go
@@ -198,9 +198,13 @@ func TobariTempDir() string {
 }
 
 func OverlayDir() string {
-	return filepath.Join(TobariTempDir(), "builds", BuildID(), "overlay")
+	return filepath.Join(TobariTempDir(), "overlay")
 }
 
 func TobariPkgJSONPath() string {
 	return filepath.Join(TobariTempDir(), "builds", BuildID(), "tobari_pkg.json")
+}
+
+func AppPath() string {
+	return filepath.Join(TobariTempDir(), "builds", BuildID(), "app", strconv.Itoa(os.Getpid()))
 }

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -255,3 +255,80 @@ func TestCacheBehavior(t *testing.T) {
 		})
 	}
 }
+
+// TestFingerprintConsistency verifies that running go test with tobari multiple times
+// produces consistent package fingerprints, allowing the Go build cache to work correctly.
+//
+// Background:
+// Go computes package fingerprints (hashes) that include file paths of source files.
+// When tobari modifies runtime/testing packages via overlay, the overlay file paths
+// must be consistent across builds. If the paths change (e.g., include a build ID),
+// the fingerprints will differ, causing "fingerprint mismatch" errors like:
+//
+//	fingerprint mismatch: runtime/coverage has X, import from testing expecting Y
+//
+// This test verifies that:
+// 1. First go test with tobari succeeds (builds everything)
+// 2. Second go test with tobari succeeds (uses cached packages with consistent fingerprints)
+func TestFingerprintConsistency(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari")
+
+	// Build tobari
+	if out, err := exec.CommandContext(ctx, "go", "build", "-o", tobariBin, "./cmd/tobari").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+
+	// Get tobari flags
+	flagsCmd := exec.CommandContext(ctx, tobariBin, "flags")
+	flagsCmd.Dir = "testdata/notobari"
+	flagsOut, err := flagsCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("tobari flags failed: %s: %v", string(flagsOut), err)
+	}
+	tobariFlags := strings.Split(strings.TrimSpace(string(flagsOut)), " ")
+
+	// Use a unique TOBARI_BUILD_ID for this test to isolate from other tests
+	buildID := "test-fingerprint-" + t.Name()
+
+	env := os.Environ()
+	env = append(env, "GOFLAGS="+strings.Join(tobariFlags, " "))
+	env = append(env, "TOBARI_BUILD_ID="+buildID)
+
+	// Clean go build cache for a fresh start
+	if out, err := exec.CommandContext(ctx, "go", "clean", "-cache").CombinedOutput(); err != nil {
+		t.Fatalf("failed to clean cache: %s: %v", string(out), err)
+	}
+
+	// First run: builds everything including overlay-modified runtime/testing packages
+	cmd1 := exec.CommandContext(ctx, "go", "test", ".", "-count=1")
+	cmd1.Env = env
+	cmd1.Dir = "testdata/notobari"
+	if out, err := cmd1.CombinedOutput(); err != nil {
+		t.Fatalf("first go test failed: %s: %v", string(out), err)
+	}
+
+	// Second run: should use cached packages
+	// Before the fix, this would fail with "fingerprint mismatch" because
+	// the overlay directory path included BuildID which changed between runs,
+	// causing different fingerprints for the same package content.
+	cmd2 := exec.CommandContext(ctx, "go", "test", ".", "-count=1")
+	cmd2.Env = env
+	cmd2.Dir = "testdata/notobari"
+	out, err := cmd2.CombinedOutput()
+	if err != nil {
+		// Check if this is a fingerprint mismatch error
+		if strings.Contains(string(out), "fingerprint mismatch") {
+			t.Fatalf("fingerprint mismatch detected - overlay paths are not consistent: %s", string(out))
+		}
+		t.Fatalf("second go test failed: %s: %v", string(out), err)
+	}
+
+	// Third run: verify it continues to work
+	cmd3 := exec.CommandContext(ctx, "go", "test", ".", "-count=1")
+	cmd3.Env = env
+	cmd3.Dir = "testdata/notobari"
+	if out, err := cmd3.CombinedOutput(); err != nil {
+		t.Fatalf("third go test failed: %s: %v", string(out), err)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix fingerprint mismatch error by using a fixed overlay directory path without BuildID
- Add atomic file writes for concurrent build safety
- Add `TestFingerprintConsistency` to verify the fix

## Background

The overlay directory path previously included `BuildID` which changed between builds, causing different fingerprints for the same package content. This led to "fingerprint mismatch" errors like:

```
fingerprint mismatch: runtime has X, import from github.com/goccy/tobari expecting Y
```

## Test plan

- [x] Verify test fails without the fix (fingerprint mismatch error)
- [x] Verify test passes with the fix
- [x] Run all existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)