### PR TITLE
Add TOBARI_COVERDIR environment variable for go test coverage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,50 @@ This will produce an output like the following. Only the coverage related to foo
 <img width="803" height="200" alt="Image" src="https://github.com/user-attachments/assets/f9b8fdf4-7d66-4e18-b9a0-af12dc06ff44" />
 <img width="418" height="223" alt="Image" src="https://github.com/user-attachments/assets/ca52ac83-10aa-47a0-99b4-fb72fe1d863a" />
 
+## Using with `go test`
+
+Tobari can also be used with `go test` to collect coverage data. When running tests with tobari, coverage metadata is written to a `tobari/tobari.json` file.
+
+### Basic Usage
+
+```console
+GOFLAGS="$(tobari flags)" go test ./...
+```
+
+This will create a `tobari/tobari.json` file in the current directory.
+
+### Specifying Output Directory
+
+You can use the `TOBARI_COVERDIR` environment variable to specify where the coverage data should be written:
+
+```console
+TOBARI_COVERDIR=/path/to/output GOFLAGS="$(tobari flags)" go test ./...
+```
+
+This will create `/path/to/output/tobari/tobari.json`.
+
+### Using with `go test -c`
+
+When building a test binary with `go test -c`, you can specify `TOBARI_COVERDIR` at runtime:
+
+```console
+# Build the test binary
+GOFLAGS="$(tobari flags)" go test -c .
+
+# Run with default output (current directory)
+./pkg.test
+
+# Run with custom output directory
+TOBARI_COVERDIR=/path/to/output ./pkg.test
+```
+
+| Scenario | Output Location |
+|----------|-----------------|
+| `go test ./...` | `./tobari/tobari.json` |
+| `TOBARI_COVERDIR=dir go test ./...` | `dir/tobari/tobari.json` |
+| `go test -c && ./pkg.test` | `./tobari/tobari.json` |
+| `go test -c && TOBARI_COVERDIR=dir ./pkg.test` | `dir/tobari/tobari.json` |
+
 ## How It Works
 
 Tobari records which Goroutine increased the counter by obtaining the Goroutine ID (GID) and Parent Goroutine ID (PGID) when increasing coverage counters.

--- a/internal/cover/testmain.go
+++ b/internal/cover/testmain.go
@@ -66,3 +66,4 @@ func addTobariImportStmt(file *ast.File) {
 		},
 	}, file.Decls...)
 }
+

--- a/internal/overlay/templates/testdeps.go.tmpl
+++ b/internal/overlay/templates/testdeps.go.tmpl
@@ -17,7 +17,10 @@ import (
 func coverProfileMap(string) map[string]string
 
 func coverTearDown(coverprofile string, gocoverdir string) (string, error) {
-	gocoverDir := os.Getenv("GOCOVERDIR")
+	gocoverDir := os.Getenv("TOBARI_COVERDIR")
+	if gocoverDir == "" {
+		gocoverDir = "."
+	}
 	m := coverProfileMap("set")
 	b, err := json.Marshal(m)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `TOBARI_COVERDIR` environment variable to specify coverage output directory when using `go test`
- Default to current directory (`./tobari/tobari.json`) when `TOBARI_COVERDIR` is not set
- Works with both `go test` and `go test -c` workflows

## Usage

| Scenario | Output Location |
|----------|-----------------|
| `go test ./...` | `./tobari/tobari.json` |
| `TOBARI_COVERDIR=dir go test ./...` | `dir/tobari/tobari.json` |
| `go test -c && ./pkg.test` | `./tobari/tobari.json` |
| `go test -c && TOBARI_COVERDIR=dir ./pkg.test` | `dir/tobari/tobari.json` |

## Test plan
- [x] Verify `go test ./...` creates `./tobari/tobari.json`
- [x] Verify `TOBARI_COVERDIR=mydir go test ./...` creates `mydir/tobari/tobari.json`
- [x] Verify `go test -c && ./pkg.test` creates `./tobari/tobari.json`
- [x] Verify `go test -c && TOBARI_COVERDIR=mydir ./pkg.test` creates `mydir/tobari/tobari.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)