### PR TITLE
Add tobari view command for interactive coverage visualization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,7 @@
 - Keep error variables in the shortest possible scope. Prefer `if err := f(); err != nil` over declaring `err` separately.
 - Always use `err` as the variable name for errors.
 - When combining multiple errors, use `errors.Join`.
+
+## Documentation Rules
+
+- When modifying the `tobari view` command, always update `docs/cli/view.md` accordingly.

--- a/cmd/tobari/main.go
+++ b/cmd/tobari/main.go
@@ -12,7 +12,7 @@ func main() {
 	ctx := context.Background()
 	c := cli.New()
 	if err := c.Run(ctx, os.Args); err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/docs/cli/view.md
+++ b/docs/cli/view.md
@@ -1,0 +1,119 @@
+# tobari view
+
+`tobari view` generates an interactive single-file HTML report from `tobari.json` (per-test coverage data).
+
+## Usage
+
+```bash
+tobari view [-o output.html] [-b binary | -s sources.tar.gz] <tobari.json>
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o` | `coverage-view.html` | Output HTML file path |
+| `-b` | - | Path to tobari-built binary with embedded sources |
+| `-s` | - | Path to tar.gz archive of extracted sources |
+
+`-b` and `-s` are mutually exclusive. If neither is specified, source files are read directly from the local filesystem using the paths in `tobari.json`.
+
+Only `tobari.json` format is accepted. Passing a coverprofile results in an error (use `tobari html` for coverprofile files).
+
+## Generated HTML Features
+
+The generated HTML is a fully self-contained single file with no external dependencies. It consists of three tabs.
+
+### Coverage Tab
+
+The main view for visualizing per-test coverage on source code.
+
+**Left Panel: Test Selection Tree**
+
+- Displays test names as a hierarchical tree split by `/` (e.g., `TestDecoder/hello/world`)
+- Checkboxes for selecting/deselecting individual tests
+- Checking a parent node selects/deselects all children
+- Test name filter (substring search)
+- Select All / Deselect All buttons
+- Tree is initially collapsed; click to expand
+- Summary showing selected test count and coverage percentage
+
+**Right Panel: Source Code Viewer**
+
+- File selection dropdown with per-file coverage percentage
+- Source code display with line numbers
+- Line-level color coding:
+  - Green: covered (executed by at least one selected test)
+  - Red: uncovered (instrumented but not executed by any selected test)
+  - No color: not instrumented
+- Dynamic merge that updates in real time as test selection changes
+
+**Compare Mode**
+
+Selecting a test pair from the Overlap Analysis tab enters compare mode.
+
+- Four-color coding:
+  - Green: covered by both tests
+  - Blue: covered by Test A only
+  - Orange: covered by Test B only
+  - Red: covered by neither test (instrumented line)
+- Color legend banner displayed above the source code
+- Diff navigation:
+  - Prev / Next buttons to jump between diff lines (A-only or B-only)
+  - Cross-file navigation (automatically switches to the next file when diffs in the current file are exhausted)
+  - Position indicator (e.g., `3 / 20`)
+  - Per-file diff count badges (click to jump to the first diff in that file)
+  - Current diff line highlighted with a blue left border
+- Exit Compare button to return to normal mode
+
+### Overlap Analysis Tab
+
+A view for analyzing coverage overlap between tests.
+
+**Coverage Overlap Matrix**
+
+- Heatmap visualizing overlap rates between top-level tests (grouped by name before `/`)
+- Cell colors represent match rates:
+  - Red: 90-100%
+  - Orange: 70-90%
+  - Yellow: 50-70%
+  - Yellow-green: 30-50%
+  - Gray: below 30%
+- Hover on a cell to show test names and overlap rate in a tooltip
+- Click a cell to enter compare mode in the Coverage tab
+
+**Overlap Rankings**
+
+- All test pairs listed by overlap rate in descending order
+- Filters:
+  - Test name search (substring match against Test A or Test B)
+  - Match rate range (Min% / Max%)
+  - Result count display (e.g., `123 / 4851 pairs`)
+- Click a row to enter compare mode in the Coverage tab
+
+**How Overlap Rate is Calculated**
+
+Overlap rate is computed using Jaccard similarity. Each test's coverage is represented as a set of signatures (file position + covered/uncovered status). The overlap rate between two tests is `|common signatures| / |union of all signatures|`. Subtest coverage is merged into their top-level parent test.
+
+### Summary Tab
+
+A view displaying overall statistics.
+
+**Overall Statistics**
+
+- Total Coverage (coverage percentage across all tests)
+- Tests (number of tests)
+- Files (number of files)
+- Lines Covered (covered lines / instrumented lines)
+
+**Per-File Coverage**
+
+- Instrumented lines, covered lines, and coverage percentage per file
+- Sorted by coverage percentage ascending
+- Includes a coverage bar
+
+**Per-Test Coverage (top-level)**
+
+- Covered lines, total instrumented lines, and coverage percentage per top-level test
+- Sorted by coverage percentage descending
+- Includes a coverage bar

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -104,6 +104,8 @@ func (c *CLI) handleSubcommand(ctx context.Context, tobariBinPath, cmd string, a
 		return c.runExtractCmd(ctx, args)
 	case "html":
 		return c.runHTMLCmd(ctx, args)
+	case "view":
+		return c.runViewCmd(ctx, args)
 	case "version":
 		return c.showVersion()
 	case "help":

--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -12,6 +12,7 @@ Commands:
     flags       Output flags for go build/test with coverage
     extract     Extract embedded source code from an instrumented binary
     html        Generate HTML coverage report from coverprofile or tobari.json
+    view        Generate interactive HTML coverage visualization from tobari.json
     version     Show version information
     help        Show this help message
 
@@ -24,6 +25,11 @@ Flags Command Options:
 
 HTML Command Options:
     -o <file>           Output HTML file path (default: coverage.html)
+    -b <binary>         Path to tobari-built binary with embedded sources
+    -s <tar.gz>         Path to tar.gz archive of extracted sources
+
+View Command Options:
+    -o <file>           Output HTML file path (default: coverage-view.html)
     -b <binary>         Path to tobari-built binary with embedded sources
     -s <tar.gz>         Path to tar.gz archive of extracted sources
 
@@ -57,6 +63,9 @@ Examples:
 
     # Generate HTML with sources from extracted tar.gz
     tobari html -o coverage.html -s sources.tar.gz profile.cover
+
+    # Generate interactive coverage visualization
+    tobari view -o report.html tobari.json
 
     # Show version
     tobari version

--- a/internal/cli/view_cmd.go
+++ b/internal/cli/view_cmd.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (c *CLI) runViewCmd(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("view", flag.ContinueOnError)
+	fs.SetOutput(c.stderr)
+	output := fs.String("o", "coverage-view.html", "output HTML file path")
+	binary := fs.String("b", "", "path to tobari-built binary with embedded sources")
+	sources := fs.String("s", "", "path to tar.gz archive of extracted sources")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() == 0 {
+		return fmt.Errorf("missing input file\nUsage: tobari view [-o output.html] [-b binary | -s sources.tar.gz] <tobari.json>")
+	}
+	for _, arg := range fs.Args()[1:] {
+		if strings.HasPrefix(arg, "-") {
+			return fmt.Errorf("flags must be specified before the input file\nUsage: tobari view [-o output.html] [-b binary | -s sources.tar.gz] <tobari.json>")
+		}
+	}
+	if *binary != "" && *sources != "" {
+		return fmt.Errorf("-b and -s flags are mutually exclusive")
+	}
+
+	inputFile := fs.Arg(0)
+
+	data, err := os.ReadFile(inputFile)
+	if err != nil {
+		return fmt.Errorf("failed to read input file %s: %w", inputFile, err)
+	}
+
+	// Only accept tobari.json format (not coverprofile)
+	if bytes.HasPrefix(bytes.TrimLeft(data, " \t\r\n"), []byte("mode:")) {
+		return fmt.Errorf("tobari view requires tobari.json input (per-test coverage data)\nUse 'tobari html' for coverprofile files")
+	}
+
+	var entriesMap map[string][]tobariJSONEntry
+	if err := json.Unmarshal(data, &entriesMap); err != nil {
+		return fmt.Errorf("failed to parse tobari.json: %w", err)
+	}
+
+	// Source resolution
+	sourceDir := ""
+	if *binary != "" || *sources != "" {
+		tmpDir, err := os.MkdirTemp("", "tobari-view-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp dir: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		tarGzPath := *sources
+		if *binary != "" {
+			tarGzPath = filepath.Join(tmpDir, "sources.tar.gz")
+			if err := extractSourcesFromBinary(ctx, *binary, tarGzPath); err != nil {
+				return fmt.Errorf("failed to extract sources from binary %s: %w", *binary, err)
+			}
+		}
+
+		if err := extractTarGz(tarGzPath, tmpDir); err != nil {
+			return fmt.Errorf("failed to extract tar.gz: %w", err)
+		}
+		sourceDir = tmpDir
+	}
+
+	// Collect unique file paths and build index
+	filePaths, fileIndexMap := buildFileIndex(entriesMap)
+
+	// Shorten file paths for display
+	shortNames := shortenFilePaths(filePaths)
+
+	// Read source files
+	files := make([]*viewFile, len(filePaths))
+	for i, p := range filePaths {
+		actualPath := p
+		if sourceDir != "" {
+			actualPath = filepath.Join(sourceDir, p)
+		}
+
+		content, err := os.ReadFile(actualPath)
+		if err != nil {
+			files[i] = &viewFile{
+				Path:  p,
+				Short: shortNames[i],
+				Lines: []string{"// Source not available: " + err.Error()},
+			}
+			continue
+		}
+
+		lines := strings.Split(string(content), "\n")
+		// Remove trailing empty line from Split
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+
+		files[i] = &viewFile{
+			Path:  p,
+			Short: shortNames[i],
+			Lines: lines,
+		}
+	}
+
+	// Build view data
+	vd := buildViewData(entriesMap, files, fileIndexMap)
+
+	// Generate HTML
+	outputFile, err := os.Create(*output)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", *output, err)
+	}
+	defer func() { _ = outputFile.Close() }()
+
+	if err := generateViewHTML(outputFile, vd); err != nil {
+		return fmt.Errorf("failed to generate HTML: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(c.stdout, "Interactive coverage report written to %s\n", *output); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cli/view_cmd_test.go
+++ b/internal/cli/view_cmd_test.go
@@ -1,0 +1,285 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunViewCmd_TobariJSON(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPath := createTestGoFile(t, srcDir)
+	jsonPath := createTobariJSON(t, srcDir, srcPath)
+	outputPath := filepath.Join(t.TempDir(), "out.html")
+
+	var stdout, stderr bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &stderr}
+
+	if err := c.runViewCmd(context.Background(), []string{"-o", outputPath, jsonPath}); err != nil {
+		t.Fatalf("runViewCmd() error = %v\nstderr: %s", err, stderr.String())
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output HTML: %v", err)
+	}
+	html := string(data)
+
+	if !strings.Contains(html, "<!DOCTYPE html>") {
+		t.Error("output HTML does not contain <!DOCTYPE html>")
+	}
+	if !strings.Contains(html, "Tobari Coverage Report") {
+		t.Error("output HTML does not contain title")
+	}
+	if !strings.Contains(html, "TestAdd") {
+		t.Error("output HTML does not contain test name TestAdd")
+	}
+	if !strings.Contains(html, "TestMain") {
+		t.Error("output HTML does not contain test name TestMain")
+	}
+	if !strings.Contains(stdout.String(), "Interactive coverage report written to") {
+		t.Errorf("stdout = %q, want to contain success message", stdout.String())
+	}
+}
+
+func TestRunViewCmd_TobariJSONWithSources(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPath := createTestGoFile(t, srcDir)
+	tarGzPath := createSourceTarGz(t, srcDir, srcPath)
+	jsonPath := createTobariJSON(t, srcDir, srcPath)
+	outputPath := filepath.Join(t.TempDir(), "out.html")
+
+	var stdout, stderr bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &stderr}
+
+	if err := c.runViewCmd(context.Background(), []string{"-o", outputPath, "-s", tarGzPath, jsonPath}); err != nil {
+		t.Fatalf("runViewCmd() error = %v\nstderr: %s", err, stderr.String())
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output HTML: %v", err)
+	}
+	if !strings.Contains(string(data), "func add") {
+		t.Error("output HTML does not contain source code content")
+	}
+}
+
+func TestRunViewCmd_DefaultOutput(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPath := createTestGoFile(t, srcDir)
+	jsonPath := createTobariJSON(t, srcDir, srcPath)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outDir := t.TempDir()
+	if err := os.Chdir(outDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	var stdout, stderr bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &stderr}
+
+	if err := c.runViewCmd(context.Background(), []string{jsonPath}); err != nil {
+		t.Fatalf("runViewCmd() error = %v\nstderr: %s", err, stderr.String())
+	}
+
+	defaultOutput := filepath.Join(outDir, "coverage-view.html")
+	if _, err := os.Stat(defaultOutput); err != nil {
+		t.Errorf("default output file not created: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "coverage-view.html") {
+		t.Errorf("stdout = %q, want to contain 'coverage-view.html'", stdout.String())
+	}
+}
+
+func TestRunViewCmd_RejectsCoverprofile(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPath := createTestGoFile(t, srcDir)
+	profilePath := createCoverprofile(t, srcDir, srcPath)
+
+	var stdout, stderr bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &stderr}
+
+	err := c.runViewCmd(context.Background(), []string{profilePath})
+	if err == nil {
+		t.Fatal("expected error for coverprofile input, got nil")
+	}
+	if !strings.Contains(err.Error(), "tobari view requires tobari.json") {
+		t.Errorf("error = %q, want to contain tobari.json requirement message", err.Error())
+	}
+}
+
+func TestRunViewCmd_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantErrMsg string
+	}{
+		{
+			name:       "missing input file",
+			args:       []string{},
+			wantErrMsg: "missing input file",
+		},
+		{
+			name:       "mutually exclusive -b and -s",
+			args:       []string{"-b", "bin", "-s", "src.tar.gz", "input"},
+			wantErrMsg: "-b and -s flags are mutually exclusive",
+		},
+		{
+			name:       "flags after input file",
+			args:       []string{"input.json", "-o", "out.html"},
+			wantErrMsg: "flags must be specified before the input file",
+		},
+		{
+			name:       "nonexistent input file",
+			args:       []string{"/nonexistent/path/input.json"},
+			wantErrMsg: "failed to read input file",
+		},
+		{
+			name:       "invalid json input",
+			args:       nil,
+			wantErrMsg: "failed to parse tobari.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := tt.args
+
+			if tt.name == "invalid json input" {
+				tmpDir := t.TempDir()
+				invalidJSON := filepath.Join(tmpDir, "bad.json")
+				if err := os.WriteFile(invalidJSON, []byte("{invalid json}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				args = []string{invalidJSON}
+			}
+
+			var stdout, stderr bytes.Buffer
+			c := &CLI{stdout: &stdout, stderr: &stderr}
+
+			err := c.runViewCmd(context.Background(), args)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
+}
+
+func TestBuildTestTree(t *testing.T) {
+	names := []string{
+		"TestAdd",
+		"TestDecoder",
+		"TestDecoder/hello",
+		"TestDecoder/world",
+		"TestEncoder",
+		"TestEncoder/a",
+		"TestEncoder/b",
+	}
+	tree := buildTestTree(names)
+
+	if len(tree) != 3 {
+		t.Fatalf("expected 3 top-level nodes, got %d", len(tree))
+	}
+
+	// TestAdd
+	if tree[0].Name != "TestAdd" || !tree[0].IsLeaf || len(tree[0].Children) != 0 {
+		t.Errorf("TestAdd node: name=%s, isLeaf=%v, children=%d", tree[0].Name, tree[0].IsLeaf, len(tree[0].Children))
+	}
+
+	// TestDecoder
+	if tree[1].Name != "TestDecoder" || !tree[1].IsLeaf || len(tree[1].Children) != 2 {
+		t.Errorf("TestDecoder node: name=%s, isLeaf=%v, children=%d", tree[1].Name, tree[1].IsLeaf, len(tree[1].Children))
+	}
+	if tree[1].Children[0].Name != "hello" || tree[1].Children[0].FullName != "TestDecoder/hello" {
+		t.Errorf("TestDecoder/hello: name=%s, fullName=%s", tree[1].Children[0].Name, tree[1].Children[0].FullName)
+	}
+
+	// TestEncoder
+	if tree[2].Name != "TestEncoder" || !tree[2].IsLeaf || len(tree[2].Children) != 2 {
+		t.Errorf("TestEncoder node: name=%s, isLeaf=%v, children=%d", tree[2].Name, tree[2].IsLeaf, len(tree[2].Children))
+	}
+}
+
+func TestConvertToLineCoverage(t *testing.T) {
+	entries := []tobariJSONEntry{
+		{FileName: "a.go", Start: tobariEntryPos{Line: 3, Column: 1}, End: tobariEntryPos{Line: 5, Column: 2}, Count: 1},
+		{FileName: "a.go", Start: tobariEntryPos{Line: 7, Column: 1}, End: tobariEntryPos{Line: 8, Column: 2}, Count: 0}, // not covered
+		{FileName: "b.go", Start: tobariEntryPos{Line: 10, Column: 1}, End: tobariEntryPos{Line: 12, Column: 2}, Count: 2},
+	}
+	fileIndexMap := map[string]int{"a.go": 0, "b.go": 1}
+	cov := convertToLineCoverage(entries, fileIndexMap)
+
+	// a.go: lines 3,4,5 covered (count=1), lines 7,8 NOT covered (count=0)
+	aLines := cov[0]
+	if len(aLines) != 3 {
+		t.Fatalf("a.go: expected 3 covered lines, got %d: %v", len(aLines), aLines)
+	}
+
+	// b.go: lines 10,11,12 covered
+	bLines := cov[1]
+	if len(bLines) != 3 {
+		t.Fatalf("b.go: expected 3 covered lines, got %d: %v", len(bLines), bLines)
+	}
+}
+
+func TestShortenFilePaths(t *testing.T) {
+	paths := []string{
+		"/Users/user/project/pkg/decode.go",
+		"/Users/user/project/pkg/encode.go",
+		"/Users/user/project/internal/scanner.go",
+	}
+	short := shortenFilePaths(paths)
+	if len(short) != 3 {
+		t.Fatalf("expected 3 paths, got %d", len(short))
+	}
+	// Common prefix is /Users/user/project/
+	for _, s := range short {
+		if strings.HasPrefix(s, "/Users/user/project/") {
+			t.Errorf("path %q still has common prefix", s)
+		}
+	}
+}
+
+func TestComputeOverlaps(t *testing.T) {
+	entriesMap := map[string][]tobariJSONEntry{
+		"TestA": {
+			{FileName: "a.go", Start: tobariEntryPos{Line: 1, Column: 1}, End: tobariEntryPos{Line: 3, Column: 2}, StatementCount: 1, Count: 1},
+			{FileName: "a.go", Start: tobariEntryPos{Line: 5, Column: 1}, End: tobariEntryPos{Line: 7, Column: 2}, StatementCount: 1, Count: 1},
+		},
+		"TestB": {
+			{FileName: "a.go", Start: tobariEntryPos{Line: 1, Column: 1}, End: tobariEntryPos{Line: 3, Column: 2}, StatementCount: 1, Count: 1},
+			{FileName: "a.go", Start: tobariEntryPos{Line: 5, Column: 1}, End: tobariEntryPos{Line: 7, Column: 2}, StatementCount: 1, Count: 0},
+		},
+	}
+	fileIndexMap := map[string]int{"a.go": 0}
+
+	overlaps := computeOverlaps(entriesMap, fileIndexMap)
+	if len(overlaps) != 1 {
+		t.Fatalf("expected 1 overlap pair, got %d", len(overlaps))
+	}
+	pair := overlaps[0]
+	if pair.TestA != "TestA" || pair.TestB != "TestB" {
+		t.Errorf("pair: %s <-> %s", pair.TestA, pair.TestB)
+	}
+	// TestA sigs: (0:1:1:3:2:1), (0:5:1:7:2:1)
+	// TestB sigs: (0:1:1:3:2:1), (0:5:1:7:2:0)
+	// Common: (0:1:1:3:2:1) = 1
+	// Total: 3 unique sigs
+	if pair.Common != 1 {
+		t.Errorf("expected common=1, got %d", pair.Common)
+	}
+	if pair.Total != 3 {
+		t.Errorf("expected total=3, got %d", pair.Total)
+	}
+}

--- a/internal/cli/view_data.go
+++ b/internal/cli/view_data.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -332,7 +331,3 @@ func buildFileIndex(entriesMap map[string][]tobariJSONEntry) ([]string, map[stri
 	return paths, indexMap
 }
 
-// formatPercent formats a float64 ratio as a percentage string.
-func formatPercent(ratio float64) string {
-	return fmt.Sprintf("%.1f%%", ratio*100)
-}

--- a/internal/cli/view_data.go
+++ b/internal/cli/view_data.go
@@ -1,0 +1,338 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// viewData is the top-level structure serialized as JSON into the HTML.
+type viewData struct {
+	Tests      []*viewTest    `json:"tests"`
+	TestTree   []*testNode    `json:"testTree"`
+	Files      []*viewFile    `json:"files"`
+	Overlaps   []*overlapPair `json:"overlaps"`
+	InstrLines map[int][]int  `json:"instrLines"` // fileIndex → all instrumented line numbers (Count >= 0)
+}
+
+// viewTest represents a test with line-level coverage (compact representation).
+type viewTest struct {
+	Name     string        `json:"n"`
+	Coverage map[int][]int `json:"c"` // fileIndex → sorted list of covered line numbers
+}
+
+// viewFile represents a source file with its content.
+type viewFile struct {
+	Path  string   `json:"path"`
+	Short string   `json:"short"`
+	Lines []string `json:"lines"`
+}
+
+// testNode represents a node in the test name tree.
+type testNode struct {
+	Name     string      `json:"name"`
+	FullName string      `json:"fullName"`
+	IsLeaf   bool        `json:"isLeaf"`
+	Children []*testNode `json:"children,omitempty"`
+}
+
+// overlapPair stores the overlap metric between two tests.
+type overlapPair struct {
+	TestA     string  `json:"testA"`
+	TestB     string  `json:"testB"`
+	MatchRate float64 `json:"matchRate"`
+	Common    int     `json:"common"`
+	Total     int     `json:"total"`
+}
+
+// buildTestTree constructs a hierarchical tree from test names split by "/".
+func buildTestTree(testNames []string) []*testNode {
+	sort.Strings(testNames)
+
+	root := &testNode{Children: make([]*testNode, 0)}
+
+	for _, name := range testNames {
+		parts := strings.Split(name, "/")
+		current := root
+		for i, part := range parts {
+			fullName := strings.Join(parts[:i+1], "/")
+			child := findChild(current, part)
+			if child == nil {
+				child = &testNode{
+					Name:     part,
+					FullName: fullName,
+					Children: make([]*testNode, 0),
+				}
+				current.Children = append(current.Children, child)
+			}
+			if i == len(parts)-1 {
+				child.IsLeaf = true
+			}
+			current = child
+		}
+	}
+
+	return root.Children
+}
+
+func findChild(parent *testNode, name string) *testNode {
+	for _, c := range parent.Children {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// convertToLineCoverage converts raw tobariJSONEntry entries to a line-level coverage map.
+// Returns fileIndex → sorted list of covered line numbers.
+func convertToLineCoverage(entries []tobariJSONEntry, fileIndexMap map[string]int) map[int][]int {
+	coveredLines := make(map[int]map[int]struct{})
+
+	for _, e := range entries {
+		if e.Count <= 0 {
+			continue
+		}
+		fi, ok := fileIndexMap[e.FileName]
+		if !ok {
+			continue
+		}
+		if coveredLines[fi] == nil {
+			coveredLines[fi] = make(map[int]struct{})
+		}
+		for line := e.Start.Line; line <= e.End.Line; line++ {
+			coveredLines[fi][line] = struct{}{}
+		}
+	}
+
+	result := make(map[int][]int, len(coveredLines))
+	for fi, lines := range coveredLines {
+		sorted := make([]int, 0, len(lines))
+		for line := range lines {
+			sorted = append(sorted, line)
+		}
+		sort.Ints(sorted)
+		result[fi] = sorted
+	}
+	return result
+}
+
+// computeOverlaps computes Jaccard similarity between top-level tests.
+// Top-level tests are determined by the first segment before "/".
+// Child test coverages are merged into their top-level parent.
+func computeOverlaps(entriesMap map[string][]tobariJSONEntry, fileIndexMap map[string]int) []*overlapPair {
+	// Group entries by top-level test name
+	type sigKey struct {
+		fi        int
+		startLine int
+		startCol  int
+		endLine   int
+		endCol    int
+		covered   int
+	}
+
+	topLevelSigs := make(map[string]map[sigKey]struct{})
+
+	for testName, entries := range entriesMap {
+		topLevel := strings.SplitN(testName, "/", 2)[0]
+		if topLevelSigs[topLevel] == nil {
+			topLevelSigs[topLevel] = make(map[sigKey]struct{})
+		}
+		for _, e := range entries {
+			fi, ok := fileIndexMap[e.FileName]
+			if !ok {
+				continue
+			}
+			covered := 0
+			if e.Count > 0 {
+				covered = 1
+			}
+			key := sigKey{
+				fi:        fi,
+				startLine: e.Start.Line,
+				startCol:  e.Start.Column,
+				endLine:   e.End.Line,
+				endCol:    e.End.Column,
+				covered:   covered,
+			}
+			topLevelSigs[topLevel][key] = struct{}{}
+		}
+	}
+
+	// Collect sorted top-level test names
+	var topLevelNames []string
+	for name := range topLevelSigs {
+		topLevelNames = append(topLevelNames, name)
+	}
+	sort.Strings(topLevelNames)
+
+	// Compute pairwise Jaccard similarity
+	var pairs []*overlapPair
+	for i := 0; i < len(topLevelNames); i++ {
+		sigsA := topLevelSigs[topLevelNames[i]]
+		for j := i + 1; j < len(topLevelNames); j++ {
+			sigsB := topLevelSigs[topLevelNames[j]]
+
+			common := 0
+			for sig := range sigsA {
+				if _, ok := sigsB[sig]; ok {
+					common++
+				}
+			}
+			total := len(sigsA) + len(sigsB) - common
+			if total == 0 {
+				continue
+			}
+			rate := float64(common) / float64(total)
+			pairs = append(pairs, &overlapPair{
+				TestA:     topLevelNames[i],
+				TestB:     topLevelNames[j],
+				MatchRate: rate,
+				Common:    common,
+				Total:     total,
+			})
+		}
+	}
+
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].MatchRate > pairs[j].MatchRate
+	})
+
+	return pairs
+}
+
+// shortenFilePaths removes the common directory prefix from file paths.
+func shortenFilePaths(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	if len(paths) == 1 {
+		return []string{filepath.Base(paths[0])}
+	}
+
+	// Find common prefix
+	prefix := filepath.Dir(paths[0])
+	for _, p := range paths[1:] {
+		dir := filepath.Dir(p)
+		for !strings.HasPrefix(dir, prefix) && prefix != "" {
+			prefix = filepath.Dir(prefix)
+		}
+	}
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	result := make([]string, len(paths))
+	for i, p := range paths {
+		short := strings.TrimPrefix(p, prefix)
+		if short == "" {
+			short = filepath.Base(p)
+		}
+		result[i] = short
+	}
+	return result
+}
+
+// collectUncoveredLines determines which lines in each file have coverage entries
+// but are not covered by the given entries.
+func collectAllCoverageLines(entriesMap map[string][]tobariJSONEntry, fileIndexMap map[string]int) map[int]map[int]struct{} {
+	allLines := make(map[int]map[int]struct{})
+	for _, entries := range entriesMap {
+		for _, e := range entries {
+			fi, ok := fileIndexMap[e.FileName]
+			if !ok {
+				continue
+			}
+			if allLines[fi] == nil {
+				allLines[fi] = make(map[int]struct{})
+			}
+			for line := e.Start.Line; line <= e.End.Line; line++ {
+				allLines[fi][line] = struct{}{}
+			}
+		}
+	}
+	return allLines
+}
+
+// buildViewData constructs the viewData from parsed tobari.json entries and source files.
+func buildViewData(entriesMap map[string][]tobariJSONEntry, files []*viewFile, fileIndexMap map[string]int) *viewData {
+	// Build tests with line-level coverage
+	var testNames []string
+	for name := range entriesMap {
+		testNames = append(testNames, name)
+	}
+	sort.Strings(testNames)
+
+	tests := make([]*viewTest, 0, len(testNames))
+	for _, name := range testNames {
+		entries := entriesMap[name]
+		cov := convertToLineCoverage(entries, fileIndexMap)
+		// Only include non-empty coverage
+		if len(cov) > 0 {
+			tests = append(tests, &viewTest{
+				Name:     name,
+				Coverage: cov,
+			})
+		} else {
+			tests = append(tests, &viewTest{
+				Name:     name,
+				Coverage: nil,
+			})
+		}
+	}
+
+	// Build test tree
+	tree := buildTestTree(testNames)
+
+	// Compute overlaps
+	overlaps := computeOverlaps(entriesMap, fileIndexMap)
+
+	// Compute all instrumented lines per file (lines from any entry, regardless of Count)
+	allInstrLines := collectAllCoverageLines(entriesMap, fileIndexMap)
+	instrLines := make(map[int][]int, len(allInstrLines))
+	for fi, lineSet := range allInstrLines {
+		sorted := make([]int, 0, len(lineSet))
+		for line := range lineSet {
+			sorted = append(sorted, line)
+		}
+		sort.Ints(sorted)
+		instrLines[fi] = sorted
+	}
+
+	return &viewData{
+		Tests:      tests,
+		TestTree:   tree,
+		Files:      files,
+		Overlaps:   overlaps,
+		InstrLines: instrLines,
+	}
+}
+
+// buildFileIndex collects unique file paths from all entries and returns
+// the sorted paths and a map from path to index.
+func buildFileIndex(entriesMap map[string][]tobariJSONEntry) ([]string, map[string]int) {
+	pathSet := make(map[string]struct{})
+	for _, entries := range entriesMap {
+		for _, e := range entries {
+			pathSet[e.FileName] = struct{}{}
+		}
+	}
+
+	paths := make([]string, 0, len(pathSet))
+	for p := range pathSet {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	indexMap := make(map[string]int, len(paths))
+	for i, p := range paths {
+		indexMap[p] = i
+	}
+	return paths, indexMap
+}
+
+// formatPercent formats a float64 ratio as a percentage string.
+func formatPercent(ratio float64) string {
+	return fmt.Sprintf("%.1f%%", ratio*100)
+}

--- a/internal/cli/view_html.go
+++ b/internal/cli/view_html.go
@@ -1,0 +1,962 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"text/template"
+)
+
+func generateViewHTML(w io.Writer, data *viewData) error {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	tmpl, err := template.New("view").Parse(viewHTMLTemplate)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(w, map[string]string{
+		"DataJSON": string(jsonData),
+	})
+}
+
+const viewHTMLTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Tobari Coverage Report</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#ffffff;--bg-secondary:#f8f9fa;--bg-tertiary:#e9ecef;
+  --text:#1a1a2e;--text-secondary:#495057;--text-muted:#868e96;
+  --border:#dee2e6;--border-light:#e9ecef;
+  --accent:#4263eb;--accent-light:#dbe4ff;
+  --cov-hit-bg:#dcfce7;--cov-hit-text:#166534;
+  --cov-miss-bg:#fee2e2;--cov-miss-text:#991b1b;
+  --font-mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+  --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  --radius:6px;
+  --cmp-a:#dbeafe;--cmp-a-text:#1e40af;
+  --cmp-b:#fef3c7;--cmp-b-text:#92400e;
+  --cmp-both:#dcfce7;--cmp-both-text:#166534;
+  --cmp-none:#fee2e2;--cmp-none-text:#991b1b;
+}
+html,body{height:100%;font-family:var(--font-sans);font-size:14px;color:var(--text);background:var(--bg)}
+a{color:var(--accent);text-decoration:none}
+
+.header{padding:12px 20px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:16px;background:var(--bg)}
+.header h1{font-size:16px;font-weight:600;white-space:nowrap}
+.header .badge{font-size:12px;color:var(--text-muted);background:var(--bg-secondary);padding:2px 8px;border-radius:10px}
+
+.tabs{display:flex;border-bottom:1px solid var(--border);background:var(--bg);padding:0 20px}
+.tab{padding:10px 20px;cursor:pointer;font-size:13px;font-weight:500;color:var(--text-secondary);border-bottom:2px solid transparent;transition:all .15s}
+.tab:hover{color:var(--text)}
+.tab.active{color:var(--accent);border-bottom-color:var(--accent)}
+.tab-content{display:none;height:calc(100vh - 95px);overflow:hidden}
+.tab-content.active{display:flex;flex-direction:column}
+
+/* Coverage Tab */
+.coverage-layout{display:flex;flex:1;overflow:hidden}
+.test-panel{width:280px;min-width:200px;border-right:1px solid var(--border);display:flex;flex-direction:column;background:var(--bg)}
+.test-panel-header{padding:10px 12px;border-bottom:1px solid var(--border-light);display:flex;flex-direction:column;gap:6px}
+.test-filter{width:100%;padding:5px 8px;border:1px solid var(--border);border-radius:var(--radius);font-size:12px;outline:none}
+.test-filter:focus{border-color:var(--accent)}
+.test-actions{display:flex;gap:4px;flex-wrap:wrap}
+.test-actions button{flex:1;padding:4px 8px;font-size:11px;border:1px solid var(--border);border-radius:var(--radius);background:var(--bg);cursor:pointer;color:var(--text-secondary);min-width:0}
+.test-actions button:hover{background:var(--bg-secondary)}
+.test-tree{flex:1;overflow-y:auto;padding:4px 0}
+.test-stats{padding:8px 12px;border-top:1px solid var(--border-light);font-size:11px;color:var(--text-secondary)}
+
+.tree-node{user-select:none}
+.tree-label{display:flex;align-items:center;padding:2px 8px;cursor:pointer;font-size:12px;line-height:1.6}
+.tree-label:hover{background:var(--bg-secondary)}
+.tree-toggle{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center;font-size:10px;color:var(--text-muted);flex-shrink:0}
+.tree-toggle.has-children{cursor:pointer}
+.tree-toggle.has-children:hover{color:var(--text)}
+.tree-checkbox{margin:0 4px 0 0;cursor:pointer;accent-color:var(--accent)}
+.tree-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+.tree-children{display:none}
+.tree-node.expanded>.tree-children{display:block}
+.tree-children .tree-label{padding-left:calc(var(--depth,0)*16px + 8px)}
+
+.source-panel{flex:1;display:flex;flex-direction:column;overflow:hidden}
+.source-header{padding:8px 12px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.file-select{padding:4px 8px;border:1px solid var(--border);border-radius:var(--radius);font-size:12px;font-family:var(--font-mono);max-width:100%;outline:none;background:var(--bg)}
+
+/* Compare banner */
+.compare-banner{padding:8px 12px;background:var(--bg-secondary);border-bottom:1px solid var(--border-light);font-size:12px;display:none;flex-direction:column;gap:6px}
+.compare-banner.active{display:flex}
+.compare-banner .cmp-label{display:inline-flex;align-items:center;gap:4px}
+.compare-banner .cmp-swatch{display:inline-block;width:12px;height:12px;border-radius:2px}
+.compare-banner button{padding:3px 10px;font-size:11px;border:1px solid var(--border);border-radius:var(--radius);background:var(--bg);cursor:pointer;color:var(--text-secondary)}
+.compare-banner button:hover{background:var(--bg-tertiary)}
+.compare-legend{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.compare-nav{display:flex;align-items:center;gap:8px;width:100%;flex-wrap:wrap}
+.compare-nav-label{font-size:11px;color:var(--text-secondary);font-weight:600}
+.diff-badges{display:flex;gap:4px;flex:1;flex-wrap:wrap}
+.diff-badge{padding:2px 8px;font-size:11px;border-radius:10px;background:var(--bg-tertiary);cursor:pointer;white-space:nowrap}
+.diff-badge:hover{background:var(--border)}
+.diff-badge.active{background:var(--accent-light);color:var(--accent)}
+.diff-nav-controls{display:flex;align-items:center;gap:6px}
+#diff-counter{font-size:11px;color:var(--text-secondary);min-width:60px;text-align:center}
+.line-diff-focus .line-no{border-left:4px solid var(--accent) !important}
+
+.source-code{flex:1;overflow:auto;font-family:var(--font-mono);font-size:13px;line-height:1.6}
+.source-table{border-collapse:collapse;width:100%}
+.source-table td{padding:0;white-space:pre;vertical-align:top}
+.line-no{text-align:right;padding:0 12px 0 8px !important;color:var(--text-muted);user-select:none;width:1px;border-right:1px solid var(--border-light);font-size:12px}
+.line-content{padding:0 8px !important}
+.line-hit{background:var(--cov-hit-bg)}
+.line-hit .line-no{color:var(--cov-hit-text);background:rgba(22,101,52,0.06)}
+.line-miss{background:var(--cov-miss-bg)}
+.line-miss .line-no{color:var(--cov-miss-text);background:rgba(153,27,27,0.06)}
+.line-cmp-both{background:var(--cmp-both)}
+.line-cmp-both .line-no{color:var(--cmp-both-text);background:rgba(22,101,52,0.06)}
+.line-cmp-a{background:var(--cmp-a)}
+.line-cmp-a .line-no{color:var(--cmp-a-text);background:rgba(30,64,175,0.06)}
+.line-cmp-b{background:var(--cmp-b)}
+.line-cmp-b .line-no{color:var(--cmp-b-text);background:rgba(146,64,14,0.06)}
+.line-cmp-none{background:var(--cov-miss-bg)}
+.line-cmp-none .line-no{color:var(--cov-miss-text);background:rgba(153,27,27,0.06)}
+
+/* Overlap Tab */
+.overlap-layout{flex:1;overflow-y:auto;padding:20px}
+.overlap-section{margin-bottom:24px}
+.overlap-section h2{font-size:15px;font-weight:600;margin-bottom:12px}
+.matrix-container{overflow:auto;margin-bottom:16px}
+.matrix-legend{display:flex;gap:16px;font-size:12px;color:var(--text-secondary);margin-bottom:16px;flex-wrap:wrap}
+.matrix-legend span{display:flex;align-items:center;gap:4px}
+.legend-dot{width:12px;height:12px;border-radius:50%;display:inline-block}
+
+.overlap-filter{display:flex;align-items:center;gap:12px;margin-bottom:16px;flex-wrap:wrap}
+.overlap-filter input[type="text"]{padding:5px 8px;border:1px solid var(--border);border-radius:var(--radius);font-size:12px;outline:none;width:200px}
+.overlap-filter input[type="text"]:focus{border-color:var(--accent)}
+.overlap-filter label{font-size:12px;color:var(--text-secondary);display:flex;align-items:center;gap:4px}
+.overlap-filter input[type="number"]{width:60px;padding:4px 6px;border:1px solid var(--border);border-radius:var(--radius);font-size:12px;outline:none;text-align:center}
+.overlap-filter input[type="number"]:focus{border-color:var(--accent)}
+.overlap-filter-count{font-size:12px;color:var(--text-muted);margin-left:auto}
+
+.overlap-table{width:100%;border-collapse:collapse;font-size:13px}
+.overlap-table th{text-align:left;padding:8px 12px;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-secondary);font-size:12px}
+.overlap-table td{padding:8px 12px;border-bottom:1px solid var(--border-light)}
+.overlap-table tr{cursor:pointer}
+.overlap-table tbody tr:hover{background:var(--bg-secondary)}
+.match-bar{display:inline-block;height:6px;border-radius:3px;margin-right:8px;vertical-align:middle}
+
+/* Summary Tab */
+.summary-layout{flex:1;overflow-y:auto;padding:20px}
+.summary-stats{display:flex;gap:16px;margin-bottom:24px;flex-wrap:wrap}
+.stat-card{background:var(--bg-secondary);border-radius:var(--radius);padding:16px 20px;flex:1;min-width:150px}
+.stat-value{font-size:24px;font-weight:700;color:var(--text)}
+.stat-label{font-size:12px;color:var(--text-secondary);margin-top:2px}
+.summary-section{margin-bottom:24px}
+.summary-section h2{font-size:15px;font-weight:600;margin-bottom:12px}
+.summary-table{width:100%;border-collapse:collapse;font-size:13px}
+.summary-table th{text-align:left;padding:8px 12px;border-bottom:2px solid var(--border);font-weight:600;color:var(--text-secondary);font-size:12px}
+.summary-table td{padding:8px 12px;border-bottom:1px solid var(--border-light)}
+.cov-bar{display:inline-block;width:60px;height:6px;border-radius:3px;background:var(--bg-tertiary);margin-right:6px;vertical-align:middle}
+.cov-bar-fill{display:block;height:100%;border-radius:3px}
+
+.svg-tooltip{position:fixed;background:rgba(0,0,0,0.85);color:#fff;padding:6px 10px;border-radius:4px;font-size:12px;pointer-events:none;z-index:1000;white-space:nowrap;display:none}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Tobari Coverage Report</h1>
+  <span class="badge" id="header-badge"></span>
+</div>
+
+<div class="tabs">
+  <div class="tab active" data-tab="coverage">Coverage</div>
+  <div class="tab" data-tab="overlap">Overlap Analysis</div>
+  <div class="tab" data-tab="summary">Summary</div>
+</div>
+
+<div class="tab-content active" id="tab-coverage">
+  <div class="coverage-layout">
+    <div class="test-panel">
+      <div class="test-panel-header">
+        <input type="text" class="test-filter" id="test-filter" placeholder="Filter tests...">
+        <div class="test-actions">
+          <button id="btn-select-all">Select All</button>
+          <button id="btn-deselect-all">Deselect All</button>
+        </div>
+      </div>
+      <div class="test-tree" id="test-tree"></div>
+      <div class="test-stats" id="test-stats"></div>
+    </div>
+    <div class="source-panel">
+      <div class="compare-banner" id="compare-banner">
+        <div class="compare-legend">
+          <span class="cmp-label"><span class="cmp-swatch" style="background:var(--cmp-both)"></span> Both</span>
+          <span class="cmp-label"><span class="cmp-swatch" style="background:var(--cmp-a)"></span> <span id="cmp-name-a">Test A</span> only</span>
+          <span class="cmp-label"><span class="cmp-swatch" style="background:var(--cmp-b)"></span> <span id="cmp-name-b">Test B</span> only</span>
+          <span class="cmp-label"><span class="cmp-swatch" style="background:var(--cov-miss-bg)"></span> Neither</span>
+        </div>
+        <div class="compare-nav">
+          <span class="compare-nav-label">Diffs:</span>
+          <div class="diff-badges" id="diff-badges"></div>
+          <div class="diff-nav-controls">
+            <button id="btn-prev-diff">Prev</button>
+            <span id="diff-counter">0 / 0</span>
+            <button id="btn-next-diff">Next</button>
+          </div>
+          <button id="btn-exit-compare">Exit Compare</button>
+        </div>
+      </div>
+      <div class="source-header">
+        <select class="file-select" id="file-select"></select>
+      </div>
+      <div class="source-code" id="source-code"></div>
+    </div>
+  </div>
+</div>
+
+<div class="tab-content" id="tab-overlap">
+  <div class="overlap-layout">
+    <div class="overlap-section">
+      <h2>Coverage Overlap Matrix</h2>
+      <div class="matrix-container" id="overlap-matrix"></div>
+      <div class="matrix-legend">
+        <span><span class="legend-dot" style="background:#dc2626"></span> 90-100%</span>
+        <span><span class="legend-dot" style="background:#ea580c"></span> 70-90%</span>
+        <span><span class="legend-dot" style="background:#f59e0b"></span> 50-70%</span>
+        <span><span class="legend-dot" style="background:#a3e635"></span> 30-50%</span>
+        <span><span class="legend-dot" style="background:#e5e7eb"></span> &lt;30%</span>
+      </div>
+    </div>
+    <div class="overlap-section">
+      <h2>Overlap Rankings</h2>
+      <div class="overlap-filter">
+        <input type="text" id="overlap-test-filter" placeholder="Filter by test name...">
+        <label>Min: <input type="number" id="overlap-min-rate" min="0" max="100" value="0" step="1">%</label>
+        <label>Max: <input type="number" id="overlap-max-rate" min="0" max="100" value="100" step="1">%</label>
+        <span class="overlap-filter-count" id="overlap-filter-count"></span>
+      </div>
+      <table class="overlap-table" id="overlap-rankings">
+        <thead><tr><th>#</th><th>Test A</th><th>Test B</th><th>Match Rate</th><th>Common / Total</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<div class="tab-content" id="tab-summary">
+  <div class="summary-layout">
+    <div class="summary-stats" id="summary-stats"></div>
+    <div class="summary-section">
+      <h2>Per-File Coverage</h2>
+      <table class="summary-table" id="file-coverage-table">
+        <thead><tr><th>File</th><th>Statements</th><th>Covered</th><th>Coverage</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="summary-section">
+      <h2>Per-Test Coverage (top-level)</h2>
+      <table class="summary-table" id="test-coverage-table">
+        <thead><tr><th>Test</th><th>Covered Lines</th><th>Total Lines</th><th>Coverage</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<div class="svg-tooltip" id="svg-tooltip"></div>
+
+<script>
+const DATA = {{.DataJSON}};
+
+// ========== State ==========
+const state = {
+  selectedTests: new Set(),
+  currentFile: 0,
+  compareMode: null, // null or { testA: string, testB: string }
+};
+
+// Precompute instrumented lines per file from DATA.instrLines (includes Count=0 entries)
+const instrLineSets = {};
+if (DATA.instrLines) {
+  for (const [fi, lines] of Object.entries(DATA.instrLines)) {
+    instrLineSets[fi] = new Set(lines);
+  }
+}
+
+// ========== Init ==========
+(function init() {
+  DATA.tests.forEach(t => state.selectedTests.add(t.n));
+
+  setupTabs();
+  renderTestTree();
+  renderFileSelect();
+  renderSourceCode();
+  updateStats();
+  renderOverlapMatrix();
+  renderOverlapRankings();
+  setupOverlapFilters();
+  renderSummary();
+  updateHeaderBadge();
+
+  document.getElementById('btn-exit-compare').addEventListener('click', exitCompareMode);
+  document.getElementById('btn-prev-diff').addEventListener('click', () => navigateDiff(-1));
+  document.getElementById('btn-next-diff').addEventListener('click', () => navigateDiff(1));
+})();
+
+// ========== Tabs ==========
+function setupTabs() {
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(tc => tc.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+    });
+  });
+}
+
+// ========== Header Badge ==========
+function updateHeaderBadge() {
+  const merged = getMergedCoverage();
+  let totalInstr = 0, totalCov = 0;
+  for (const [fi, instrSet] of Object.entries(instrLineSets)) {
+    totalInstr += instrSet.size;
+    const covSet = merged[fi] || new Set();
+    for (const l of instrSet) { if (covSet.has(l)) totalCov++; }
+  }
+  const pct = totalInstr > 0 ? (totalCov / totalInstr * 100).toFixed(1) : '0.0';
+  document.getElementById('header-badge').textContent = pct + '% coverage';
+}
+
+// ========== Test Tree ==========
+function renderTestTree() {
+  const container = document.getElementById('test-tree');
+  container.innerHTML = '';
+  renderNodes(DATA.testTree, container, 0);
+
+  document.getElementById('btn-select-all').addEventListener('click', () => {
+    DATA.tests.forEach(t => state.selectedTests.add(t.n));
+    exitCompareMode();
+    updateAllCheckboxes();
+    onSelectionChange();
+  });
+  document.getElementById('btn-deselect-all').addEventListener('click', () => {
+    state.selectedTests.clear();
+    exitCompareMode();
+    updateAllCheckboxes();
+    onSelectionChange();
+  });
+  document.getElementById('test-filter').addEventListener('input', (e) => {
+    filterTree(e.target.value.toLowerCase());
+  });
+}
+
+function renderNodes(nodes, container, depth) {
+  nodes.forEach(node => {
+    const div = document.createElement('div');
+    div.className = 'tree-node';
+    div.dataset.fullname = node.fullName;
+
+    const label = document.createElement('div');
+    label.className = 'tree-label';
+    label.style.setProperty('--depth', depth);
+
+    const toggle = document.createElement('span');
+    toggle.className = 'tree-toggle';
+    if (node.children && node.children.length > 0) {
+      toggle.className += ' has-children';
+      toggle.textContent = '\u25B8';
+      toggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        div.classList.toggle('expanded');
+        toggle.textContent = div.classList.contains('expanded') ? '\u25BE' : '\u25B8';
+      });
+    }
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.className = 'tree-checkbox';
+    cb.checked = state.selectedTests.has(node.fullName);
+    cb.addEventListener('change', () => {
+      toggleNode(node, cb.checked);
+      exitCompareMode();
+      onSelectionChange();
+    });
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'tree-name';
+    nameSpan.textContent = node.name;
+    nameSpan.title = node.fullName;
+
+    label.appendChild(toggle);
+    label.appendChild(cb);
+    label.appendChild(nameSpan);
+    div.appendChild(label);
+
+    if (node.children && node.children.length > 0) {
+      const childContainer = document.createElement('div');
+      childContainer.className = 'tree-children';
+      renderNodes(node.children, childContainer, depth + 1);
+      div.appendChild(childContainer);
+    }
+
+    container.appendChild(div);
+  });
+}
+
+function toggleNode(node, checked) {
+  if (checked) { state.selectedTests.add(node.fullName); }
+  else { state.selectedTests.delete(node.fullName); }
+  if (node.children) {
+    node.children.forEach(child => toggleNode(child, checked));
+  }
+}
+
+function updateAllCheckboxes() {
+  document.querySelectorAll('.tree-node').forEach(div => {
+    const cb = div.querySelector(':scope > .tree-label > .tree-checkbox');
+    if (cb) cb.checked = state.selectedTests.has(div.dataset.fullname);
+  });
+}
+
+function filterTree(query) {
+  document.querySelectorAll('.tree-node').forEach(div => {
+    const name = div.dataset.fullname.toLowerCase();
+    div.style.display = (!query || name.includes(query)) ? '' : 'none';
+  });
+  if (query) {
+    document.querySelectorAll('.tree-node').forEach(div => {
+      if (div.style.display === 'none') {
+        const visibleChild = div.querySelector('.tree-node[style=""]');
+        if (visibleChild) {
+          div.style.display = '';
+          div.classList.add('expanded');
+          const toggle = div.querySelector(':scope > .tree-label > .tree-toggle');
+          if (toggle) toggle.textContent = '\u25BE';
+        }
+      }
+    });
+  }
+}
+
+// ========== Selection Change ==========
+let selectionTimeout = null;
+function onSelectionChange() {
+  clearTimeout(selectionTimeout);
+  selectionTimeout = setTimeout(() => {
+    updateAllCheckboxes();
+    renderSourceCode();
+    updateStats();
+    updateHeaderBadge();
+  }, 50);
+}
+
+// ========== Merged Coverage ==========
+function getMergedCoverage() {
+  const merged = {};
+  DATA.tests.forEach(t => {
+    if (!state.selectedTests.has(t.n) || !t.c) return;
+    for (const [fi, lines] of Object.entries(t.c)) {
+      if (!merged[fi]) merged[fi] = new Set();
+      lines.forEach(l => merged[fi].add(l));
+    }
+  });
+  return merged;
+}
+
+// Get coverage for a single top-level test group (merging all subtests)
+function getTestGroupCoverage(prefix) {
+  const merged = {};
+  DATA.tests.forEach(t => {
+    if (!t.c) return;
+    if (t.n !== prefix && !t.n.startsWith(prefix + '/')) return;
+    for (const [fi, lines] of Object.entries(t.c)) {
+      if (!merged[fi]) merged[fi] = new Set();
+      lines.forEach(l => merged[fi].add(l));
+    }
+  });
+  return merged;
+}
+
+// ========== Compare Mode ==========
+function buildDiffList(testA, testB) {
+  const covA = getTestGroupCoverage(testA);
+  const covB = getTestGroupCoverage(testB);
+  const diffs = [];
+  DATA.files.forEach((f, fi) => {
+    const instrSet = instrLineSets[fi] || new Set();
+    const setA = covA[fi] || new Set();
+    const setB = covB[fi] || new Set();
+    const sortedLines = Array.from(instrSet).sort((a, b) => a - b);
+    for (const lineNo of sortedLines) {
+      const inA = setA.has(lineNo);
+      const inB = setB.has(lineNo);
+      if ((inA && !inB) || (!inA && inB)) {
+        diffs.push({ fileIndex: fi, lineNo: lineNo });
+      }
+    }
+  });
+  return diffs;
+}
+
+function renderDiffBadges() {
+  const container = document.getElementById('diff-badges');
+  container.innerHTML = '';
+  if (!state.compareMode) return;
+  const counts = {};
+  for (const d of state.compareMode.allDiffs) {
+    counts[d.fileIndex] = (counts[d.fileIndex] || 0) + 1;
+  }
+  DATA.files.forEach((f, fi) => {
+    if (!counts[fi]) return;
+    const badge = document.createElement('span');
+    badge.className = 'diff-badge' + (fi === state.currentFile ? ' active' : '');
+    badge.textContent = f.short + '(' + counts[fi] + ')';
+    badge.addEventListener('click', () => {
+      const idx = state.compareMode.allDiffs.findIndex(d => d.fileIndex === fi);
+      if (idx >= 0) {
+        state.compareMode.diffIndex = idx;
+        state.currentFile = fi;
+        document.getElementById('file-select').value = fi;
+        renderSourceCode();
+        scrollToDiffLine(state.compareMode.allDiffs[idx].lineNo);
+        updateDiffCounter();
+        updateDiffBadgeActive();
+      }
+    });
+    container.appendChild(badge);
+  });
+}
+
+function updateDiffBadgeActive() {
+  const badges = document.querySelectorAll('.diff-badge');
+  badges.forEach(b => b.classList.remove('active'));
+  const activeFi = state.currentFile;
+  badges.forEach(b => {
+    const text = b.textContent;
+    const file = DATA.files[activeFi];
+    if (file && text.startsWith(file.short + '(')) {
+      b.classList.add('active');
+    }
+  });
+}
+
+function updateDiffCounter() {
+  const el = document.getElementById('diff-counter');
+  if (!state.compareMode || state.compareMode.allDiffs.length === 0) {
+    el.textContent = '0 / 0';
+    return;
+  }
+  el.textContent = (state.compareMode.diffIndex + 1) + ' / ' + state.compareMode.allDiffs.length;
+}
+
+function navigateDiff(direction) {
+  const cmp = state.compareMode;
+  if (!cmp || cmp.allDiffs.length === 0) return;
+  cmp.diffIndex = (cmp.diffIndex + direction + cmp.allDiffs.length) % cmp.allDiffs.length;
+  const diff = cmp.allDiffs[cmp.diffIndex];
+  if (state.currentFile !== diff.fileIndex) {
+    state.currentFile = diff.fileIndex;
+    document.getElementById('file-select').value = diff.fileIndex;
+    renderSourceCode();
+    updateDiffBadgeActive();
+  }
+  scrollToDiffLine(diff.lineNo);
+  updateDiffCounter();
+}
+
+function scrollToDiffLine(lineNo) {
+  // Remove previous focus
+  const prev = document.querySelector('.line-diff-focus');
+  if (prev) prev.classList.remove('line-diff-focus');
+  // Find and scroll to the target row
+  const rows = document.querySelectorAll('.source-table tr');
+  const row = rows[lineNo - 1];
+  if (row) {
+    row.classList.add('line-diff-focus');
+    row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+}
+
+function enterCompareMode(testA, testB) {
+  const allDiffs = buildDiffList(testA, testB);
+  state.compareMode = { testA, testB, allDiffs, diffIndex: 0 };
+  document.getElementById('cmp-name-a').textContent = testA;
+  document.getElementById('cmp-name-b').textContent = testB;
+  document.getElementById('compare-banner').classList.add('active');
+  renderDiffBadges();
+  // Jump to the first diff
+  if (allDiffs.length > 0) {
+    const first = allDiffs[0];
+    if (state.currentFile !== first.fileIndex) {
+      state.currentFile = first.fileIndex;
+      document.getElementById('file-select').value = first.fileIndex;
+    }
+    renderSourceCode();
+    updateDiffCounter();
+    setTimeout(() => scrollToDiffLine(first.lineNo), 50);
+  } else {
+    renderSourceCode();
+    updateDiffCounter();
+  }
+}
+
+function exitCompareMode() {
+  state.compareMode = null;
+  document.getElementById('compare-banner').classList.remove('active');
+  document.getElementById('diff-badges').innerHTML = '';
+  document.getElementById('diff-counter').textContent = '0 / 0';
+  const prev = document.querySelector('.line-diff-focus');
+  if (prev) prev.classList.remove('line-diff-focus');
+  renderSourceCode();
+}
+
+// ========== File Select ==========
+function renderFileSelect() {
+  const sel = document.getElementById('file-select');
+  sel.innerHTML = '';
+  DATA.files.forEach((f, i) => {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = f.short;
+    sel.appendChild(opt);
+  });
+  sel.addEventListener('change', () => {
+    state.currentFile = parseInt(sel.value);
+    renderSourceCode();
+  });
+}
+
+// ========== Source Code ==========
+function renderSourceCode() {
+  const container = document.getElementById('source-code');
+  const fi = state.currentFile;
+  const file = DATA.files[fi];
+  if (!file) { container.innerHTML = ''; return; }
+
+  const instrSet = instrLineSets[fi] || new Set();
+
+  // Update file select to show coverage %
+  const merged = getMergedCoverage();
+  const sel = document.getElementById('file-select');
+  DATA.files.forEach((f, idx) => {
+    const instr = instrLineSets[idx] || new Set();
+    const cov = merged[idx] || new Set();
+    let covered = 0;
+    for (const l of instr) { if (cov.has(l)) covered++; }
+    const pct = instr.size > 0 ? (covered / instr.size * 100).toFixed(1) : '-';
+    sel.options[idx].textContent = f.short + ' (' + pct + '%)';
+  });
+
+  let html = '<table class="source-table">';
+
+  if (state.compareMode) {
+    // Compare mode: show coverage from testA vs testB with distinct colors
+    const covA = getTestGroupCoverage(state.compareMode.testA);
+    const covB = getTestGroupCoverage(state.compareMode.testB);
+    const setA = covA[fi] || new Set();
+    const setB = covB[fi] || new Set();
+
+    file.lines.forEach((line, idx) => {
+      const lineNo = idx + 1;
+      let cls = '';
+      if (instrSet.has(lineNo)) {
+        const inA = setA.has(lineNo);
+        const inB = setB.has(lineNo);
+        if (inA && inB) cls = ' class="line-cmp-both"';
+        else if (inA) cls = ' class="line-cmp-a"';
+        else if (inB) cls = ' class="line-cmp-b"';
+        else cls = ' class="line-cmp-none"';
+      }
+      const escaped = escapeHTML(line);
+      html += '<tr' + cls + '><td class="line-no">' + lineNo + '</td><td class="line-content">' + (escaped || ' ') + '</td></tr>';
+    });
+  } else {
+    // Normal mode: merged coverage
+    const coveredLines = merged[fi] || new Set();
+    file.lines.forEach((line, idx) => {
+      const lineNo = idx + 1;
+      let cls = '';
+      if (instrSet.has(lineNo)) {
+        cls = coveredLines.has(lineNo) ? ' class="line-hit"' : ' class="line-miss"';
+      }
+      const escaped = escapeHTML(line);
+      html += '<tr' + cls + '><td class="line-no">' + lineNo + '</td><td class="line-content">' + (escaped || ' ') + '</td></tr>';
+    });
+  }
+
+  html += '</table>';
+  container.innerHTML = html;
+}
+
+function escapeHTML(s) {
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+// ========== Stats ==========
+function updateStats() {
+  const merged = getMergedCoverage();
+  let totalInstr = 0, totalCov = 0;
+  for (const [fi, instrSet] of Object.entries(instrLineSets)) {
+    totalInstr += instrSet.size;
+    const cov = merged[fi] || new Set();
+    for (const l of instrSet) { if (cov.has(l)) totalCov++; }
+  }
+  const pct = totalInstr > 0 ? (totalCov / totalInstr * 100).toFixed(1) : '0.0';
+  document.getElementById('test-stats').innerHTML =
+    'Selected: ' + state.selectedTests.size + ' / ' + DATA.tests.length +
+    '<br>Coverage: ' + pct + '%';
+}
+
+// ========== Overlap Matrix (SVG) ==========
+function renderOverlapMatrix() {
+  const container = document.getElementById('overlap-matrix');
+  if (!DATA.overlaps || DATA.overlaps.length === 0) {
+    container.innerHTML = '<p style="color:var(--text-muted);font-size:13px">No overlap data available.</p>';
+    return;
+  }
+
+  const nameSet = new Set();
+  DATA.overlaps.forEach(o => { nameSet.add(o.testA); nameSet.add(o.testB); });
+  const names = Array.from(nameSet).sort();
+  const nameIndex = {};
+  names.forEach((n, i) => { nameIndex[n] = i; });
+
+  const overlapMap = {};
+  DATA.overlaps.forEach(o => {
+    overlapMap[o.testA + '|' + o.testB] = o.matchRate;
+    overlapMap[o.testB + '|' + o.testA] = o.matchRate;
+  });
+
+  const n = names.length;
+  const cellSize = Math.min(Math.max(8, Math.floor(500 / n)), 20);
+  const labelWidth = 120;
+  const labelHeight = 120;
+  const svgW = labelWidth + n * cellSize + 10;
+  const svgH = labelHeight + n * cellSize + 10;
+
+  let svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + svgW + '" height="' + svgH + '" style="font-family:var(--font-sans);font-size:10px">';
+
+  names.forEach((name, i) => {
+    const y = labelHeight + i * cellSize + cellSize / 2;
+    const short = name.length > 16 ? name.substring(0, 15) + '\u2026' : name;
+    svg += '<text x="' + (labelWidth - 4) + '" y="' + (y + 3) + '" text-anchor="end" fill="var(--text-secondary)">' + escapeHTML(short) + '</text>';
+  });
+  names.forEach((name, i) => {
+    const x = labelWidth + i * cellSize + cellSize / 2;
+    const short = name.length > 16 ? name.substring(0, 15) + '\u2026' : name;
+    svg += '<text x="' + x + '" y="' + (labelHeight - 4) + '" text-anchor="start" transform="rotate(-60,' + x + ',' + (labelHeight - 4) + ')" fill="var(--text-secondary)">' + escapeHTML(short) + '</text>';
+  });
+
+  names.forEach((nameA, i) => {
+    names.forEach((nameB, j) => {
+      if (i === j) return;
+      const key = nameA + '|' + nameB;
+      const rate = overlapMap[key] || 0;
+      if (rate < 0.01) return;
+      const x = labelWidth + j * cellSize;
+      const y = labelHeight + i * cellSize;
+      const color = rateColor(rate);
+      svg += '<rect x="' + x + '" y="' + y + '" width="' + cellSize + '" height="' + cellSize + '" fill="' + color + '" rx="1"';
+      svg += ' data-testa="' + escapeHTML(nameA) + '" data-testb="' + escapeHTML(nameB) + '"';
+      svg += ' data-tooltip="' + escapeHTML(nameA) + ' \u2194 ' + escapeHTML(nameB) + ': ' + (rate * 100).toFixed(1) + '%"';
+      svg += ' style="cursor:pointer"';
+      svg += ' onmouseenter="showTooltip(event)" onmouseleave="hideTooltip()"';
+      svg += ' onclick="onMatrixCellClick(this)"';
+      svg += '/>';
+    });
+  });
+
+  svg += '</svg>';
+  container.innerHTML = svg;
+}
+
+function rateColor(rate) {
+  if (rate >= 0.9) return '#dc2626';
+  if (rate >= 0.7) return '#ea580c';
+  if (rate >= 0.5) return '#f59e0b';
+  if (rate >= 0.3) return '#a3e635';
+  return '#e5e7eb';
+}
+
+function onMatrixCellClick(el) {
+  const testA = el.getAttribute('data-testa');
+  const testB = el.getAttribute('data-testb');
+  startCompare(testA, testB);
+}
+
+// ========== Overlap Rankings ==========
+function renderOverlapRankings() {
+  const tbody = document.querySelector('#overlap-rankings tbody');
+  tbody.innerHTML = '';
+  if (!DATA.overlaps) return;
+
+  const testQuery = (document.getElementById('overlap-test-filter').value || '').toLowerCase();
+  const minRate = parseFloat(document.getElementById('overlap-min-rate').value) || 0;
+  const maxRate = parseFloat(document.getElementById('overlap-max-rate').value);
+  const maxRateVal = isNaN(maxRate) ? 100 : maxRate;
+
+  let rank = 0;
+  let shown = 0;
+  DATA.overlaps.forEach((o) => {
+    const pctVal = o.matchRate * 100;
+    if (pctVal < minRate || pctVal > maxRateVal) return;
+    if (testQuery && !o.testA.toLowerCase().includes(testQuery) && !o.testB.toLowerCase().includes(testQuery)) return;
+
+    shown++;
+    rank++;
+    const tr = document.createElement('tr');
+    const pct = pctVal.toFixed(1);
+    const barW = Math.max(2, o.matchRate * 80);
+    tr.innerHTML =
+      '<td>' + rank + '</td>' +
+      '<td>' + escapeHTML(o.testA) + '</td>' +
+      '<td>' + escapeHTML(o.testB) + '</td>' +
+      '<td><span class="match-bar" style="width:' + barW + 'px;background:' + rateColor(o.matchRate) + '"></span>' + pct + '%</td>' +
+      '<td>' + o.common + ' / ' + o.total + '</td>';
+    tr.addEventListener('click', () => { startCompare(o.testA, o.testB); });
+    tbody.appendChild(tr);
+  });
+
+  document.getElementById('overlap-filter-count').textContent = shown + ' / ' + DATA.overlaps.length + ' pairs';
+}
+
+function setupOverlapFilters() {
+  const testFilter = document.getElementById('overlap-test-filter');
+  const minRate = document.getElementById('overlap-min-rate');
+  const maxRate = document.getElementById('overlap-max-rate');
+  let filterTimeout = null;
+  const onFilterChange = () => {
+    clearTimeout(filterTimeout);
+    filterTimeout = setTimeout(renderOverlapRankings, 150);
+  };
+  testFilter.addEventListener('input', onFilterChange);
+  minRate.addEventListener('input', onFilterChange);
+  maxRate.addEventListener('input', onFilterChange);
+}
+
+function startCompare(testA, testB) {
+  // Select both test groups and enter compare mode
+  state.selectedTests.clear();
+  selectTestAndChildren(testA);
+  selectTestAndChildren(testB);
+  updateAllCheckboxes();
+  enterCompareMode(testA, testB);
+  updateStats();
+  updateHeaderBadge();
+  document.querySelector('.tab[data-tab="coverage"]').click();
+}
+
+function selectTestAndChildren(prefix) {
+  DATA.tests.forEach(t => {
+    if (t.n === prefix || t.n.startsWith(prefix + '/')) {
+      state.selectedTests.add(t.n);
+    }
+  });
+}
+
+// ========== Summary ==========
+function renderSummary() {
+  const allMerged = {};
+  DATA.tests.forEach(t => {
+    if (!t.c) return;
+    for (const [fi, lines] of Object.entries(t.c)) {
+      if (!allMerged[fi]) allMerged[fi] = new Set();
+      lines.forEach(l => allMerged[fi].add(l));
+    }
+  });
+
+  let totalInstr = 0, totalCov = 0;
+  for (const [fi, instrSet] of Object.entries(instrLineSets)) {
+    totalInstr += instrSet.size;
+    const cov = allMerged[fi] || new Set();
+    for (const l of instrSet) { if (cov.has(l)) totalCov++; }
+  }
+
+  const pct = totalInstr > 0 ? (totalCov / totalInstr * 100).toFixed(1) : '0.0';
+  document.getElementById('summary-stats').innerHTML =
+    '<div class="stat-card"><div class="stat-value">' + pct + '%</div><div class="stat-label">Total Coverage</div></div>' +
+    '<div class="stat-card"><div class="stat-value">' + DATA.tests.length + '</div><div class="stat-label">Tests</div></div>' +
+    '<div class="stat-card"><div class="stat-value">' + DATA.files.length + '</div><div class="stat-label">Files</div></div>' +
+    '<div class="stat-card"><div class="stat-value">' + totalCov + ' / ' + totalInstr + '</div><div class="stat-label">Lines Covered</div></div>';
+
+  // Per-file coverage
+  const fileBody = document.querySelector('#file-coverage-table tbody');
+  fileBody.innerHTML = '';
+  const fileRows = [];
+  DATA.files.forEach((f, fi) => {
+    const instrSet = instrLineSets[fi] || new Set();
+    const cov = allMerged[fi] || new Set();
+    let covered = 0;
+    for (const l of instrSet) { if (cov.has(l)) covered++; }
+    const filePct = instrSet.size > 0 ? covered / instrSet.size : 0;
+    fileRows.push({ name: f.short, total: instrSet.size, covered: covered, pct: filePct });
+  });
+  fileRows.sort((a, b) => a.pct - b.pct);
+  fileRows.forEach(r => {
+    const tr = document.createElement('tr');
+    tr.innerHTML =
+      '<td>' + escapeHTML(r.name) + '</td>' +
+      '<td>' + r.total + '</td>' +
+      '<td>' + r.covered + '</td>' +
+      '<td>' + covBarHTML(r.pct) + ' ' + (r.pct * 100).toFixed(1) + '%</td>';
+    fileBody.appendChild(tr);
+  });
+
+  // Per-test coverage (top-level)
+  const testBody = document.querySelector('#test-coverage-table tbody');
+  testBody.innerHTML = '';
+  const topLevelMap = {};
+  DATA.tests.forEach(t => {
+    if (!t.c) return;
+    const topName = t.n.split('/')[0];
+    if (!topLevelMap[topName]) topLevelMap[topName] = new Set();
+    for (const [fi, lines] of Object.entries(t.c)) {
+      lines.forEach(l => topLevelMap[topName].add(fi + ':' + l));
+    }
+  });
+
+  const testRows = [];
+  for (const [name, covSet] of Object.entries(topLevelMap)) {
+    let covered = 0;
+    for (const key of covSet) {
+      const sep = key.indexOf(':');
+      const fi = key.substring(0, sep);
+      const line = parseInt(key.substring(sep + 1));
+      const instrSet = instrLineSets[fi];
+      if (instrSet && instrSet.has(line)) covered++;
+    }
+    testRows.push({ name: name, covered: covered, total: totalInstr, pct: totalInstr > 0 ? covered / totalInstr : 0 });
+  }
+  testRows.sort((a, b) => b.pct - a.pct);
+  testRows.forEach(r => {
+    const tr = document.createElement('tr');
+    tr.innerHTML =
+      '<td>' + escapeHTML(r.name) + '</td>' +
+      '<td>' + r.covered + '</td>' +
+      '<td>' + r.total + '</td>' +
+      '<td>' + covBarHTML(r.pct) + ' ' + (r.pct * 100).toFixed(1) + '%</td>';
+    testBody.appendChild(tr);
+  });
+}
+
+function covBarHTML(pct) {
+  const color = pct >= 0.8 ? '#16a34a' : pct >= 0.5 ? '#f59e0b' : '#dc2626';
+  return '<span class="cov-bar"><span class="cov-bar-fill" style="width:' + (pct * 100) + '%;background:' + color + '"></span></span>';
+}
+
+// ========== SVG Tooltip ==========
+function showTooltip(e) {
+  const tip = document.getElementById('svg-tooltip');
+  tip.textContent = e.target.getAttribute('data-tooltip');
+  tip.style.display = 'block';
+  tip.style.left = (e.clientX + 10) + 'px';
+  tip.style.top = (e.clientY - 30) + 'px';
+}
+function hideTooltip() {
+  document.getElementById('svg-tooltip').style.display = 'none';
+}
+</script>
+</body>
+</html>`


### PR DESCRIPTION
## Summary

- Add `tobari view` command that generates a self-contained interactive HTML report from `tobari.json`
- Three-tab UI: Coverage (per-test source viewer with dynamic merge), Overlap Analysis (heatmap matrix + filterable rankings + compare mode with diff navigation), Summary (per-file/per-test statistics)
- Add documentation at `docs/cli/view.md` and CLAUDE.md rule to keep it in sync
- Fix missing trailing newline in CLI error output

## Test plan

- [x] `go test ./...` passes
- [x] `tobari view -o report.html tobari.json` generates valid HTML with small and large datasets
- [x] Coverage tab: test tree selection, filter, Select All/Deselect All, dynamic coverage merge
- [x] Overlap Analysis: matrix heatmap, ranking filter (test name + match rate range), compare mode with 4-color diff and Prev/Next navigation
- [x] Summary tab: correct coverage percentages using instrumented lines as denominator
- [x] CLI error messages have trailing newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)