### PR TITLE
Add channel-based cross-goroutine coverage tracking

### DIFF
--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -770,16 +770,25 @@ func collectCommClauseCommPos(file *ast.File) map[token.Pos]struct{} {
 		if cc.Comm == nil {
 			return true
 		}
-		// Collect send and receive positions inside Comm
-		ast.Inspect(cc.Comm, func(inner ast.Node) bool {
-			if ss, ok := inner.(*ast.SendStmt); ok {
-				pos[ss.Pos()] = struct{}{}
-			}
-			if ue, ok := inner.(*ast.UnaryExpr); ok && ue.Op == token.ARROW {
+		// Collect only the select's channel operation position, not nested receives.
+		switch s := cc.Comm.(type) {
+		case *ast.SendStmt:
+			// Skip wrapping for the select's send itself.
+			pos[s.Pos()] = struct{}{}
+		case *ast.ExprStmt:
+			if ue, ok := s.X.(*ast.UnaryExpr); ok && ue.Op == token.ARROW {
+				// Skip wrapping for the select's top-level receive.
 				pos[ue.Pos()] = struct{}{}
 			}
-			return true
-		})
+		case *ast.AssignStmt:
+			for _, rhs := range s.Rhs {
+				if ue, ok := rhs.(*ast.UnaryExpr); ok && ue.Op == token.ARROW {
+					// Skip wrapping for the select's top-level receive.
+					pos[ue.Pos()] = struct{}{}
+					break
+				}
+			}
+		}
 		return true
 	})
 	return pos

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -218,18 +218,22 @@ func %[2]s_AddEmbeddedSource(string, string) bool
 //go:linkname %[2]s_TraceChan github.com/goccy/tobari/internal/tobari.TraceChan
 func %[2]s_TraceChan(uintptr, uint64, bool)
 
-func %[2]s_chanID(ch any) uintptr {
-	return (*[2]uintptr)(unsafe.Pointer(&ch))[1]
+func %[2]s_chanIDSend[T any](ch chan<- T) uintptr {
+	return *(*uintptr)(unsafe.Pointer(&ch))
 }
 
-func %[2]s_afterRecv[T any](chanID uintptr, v T) T {
-	%[2]s_TraceChan(chanID, %[2]s_GID(), false)
-	return v
+func %[2]s_chanIDRecv[T any](ch <-chan T) uintptr {
+	return *(*uintptr)(unsafe.Pointer(&ch))
 }
 
-func %[2]s_beforeSend[T any](chanID uintptr, v T) T {
-	%[2]s_TraceChan(chanID, %[2]s_GID(), true)
-	return v
+func %[2]s_afterRecvChan[T any](ch <-chan T) <-chan T {
+	%[2]s_TraceChan(%[2]s_chanIDRecv(ch), %[2]s_GID(), false)
+	return ch
+}
+
+func %[2]s_sendChan[T any](ch chan<- T) chan<- T {
+	%[2]s_TraceChan(%[2]s_chanIDSend(ch), %[2]s_GID(), true)
+	return ch
 }
 
 var _ = unsafe.Pointer(nil)
@@ -353,7 +357,6 @@ type File struct {
 	funcDep             *FunctionDependency
 	pkgcfg              *PackageConfig
 	anonymGlobalFuncIdx int
-	commClauseRecvPos   map[token.Pos]struct{} // positions of <-ch inside CommClause.Comm to skip wrapping
 }
 
 func (f *File) nextBlockIndex() int {
@@ -401,7 +404,6 @@ func addTracePointWithContent(pkgcfg *PackageConfig, dep *FunctionDependency, fi
 		funcDep:             dep,
 		pkgcfg:              pkgcfg,
 		anonymGlobalFuncIdx: 1,
-		commClauseRecvPos:   collectCommClauseRecvPos(parsedFile),
 	}
 
 	// Walk the AST and instrument code
@@ -478,24 +480,12 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 					f.addCounters(clause.Colon+1, clause.Colon+1, clause.End(), clause.Body, false)
 				}
 				return f
-			case *ast.CommClause: // select
-				for _, stmt := range n.List {
-					clause := stmt.(*ast.CommClause)
-					if f.funcDep != nil {
-						if chSrc, isSend := f.channelExprFromComm(clause.Comm); chSrc != "" {
-							if isSend {
-								// Send in select: wrap value expression via SendStmt case
-								// (handled when the walk visits the SendStmt inside Comm)
-							} else {
-								// Receive in select: insert TraceChan at case body start
-								f.edit.Insert(f.offset(clause.Colon)+1,
-									fmt.Sprintf("%s_TraceChan(%s_chanID(%s),%s_GID(),false);", tobariPkg, tobariPkg, chSrc, tobariPkg))
-							}
-						}
+				case *ast.CommClause: // select
+					for _, stmt := range n.List {
+						clause := stmt.(*ast.CommClause)
+						f.addCounters(clause.Colon+1, clause.Colon+1, clause.End(), clause.Body, false)
 					}
-					f.addCounters(clause.Colon+1, clause.Colon+1, clause.End(), clause.Body, false)
-				}
-				return f
+					return f
 			}
 		}
 		f.addCounters(n.Lbrace, n.Lbrace+1, n.Rbrace+1, n.List, true)
@@ -610,32 +600,28 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 		f.curFunc = parent
 		return nil
 	case *ast.SendStmt:
-		// ch <- value → ch <- _tobari_beforeSend(chanID, value)
+		// ch <- value → _tobari_sendChan(ch) <- value
 		if f.funcDep != nil {
-			chSrc := string(f.content[f.offset(n.Chan.Pos()):f.offset(n.Chan.End())])
-			f.edit.Insert(f.offset(n.Value.Pos()),
-				fmt.Sprintf("%s_beforeSend(%s_chanID(%s),", tobariPkg, tobariPkg, chSrc))
-			f.edit.Insert(f.offset(n.Value.End()), ")")
+			f.edit.Insert(f.offset(n.Chan.Pos()),
+				fmt.Sprintf("%s_sendChan(", tobariPkg))
+			f.edit.Insert(f.offset(n.Chan.End()), ")")
 		}
 	case *ast.UnaryExpr:
-		// <-ch → _tobari_afterRecv(chanID, <-ch)
+		// <-ch → <-_tobari_afterRecvChan(ch)
 		if n.Op == token.ARROW && f.funcDep != nil {
-			if _, skip := f.commClauseRecvPos[n.Pos()]; !skip {
-				chSrc := string(f.content[f.offset(n.X.Pos()):f.offset(n.X.End())])
-				f.edit.Insert(f.offset(n.Pos()),
-					fmt.Sprintf("%s_afterRecv(%s_chanID(%s),", tobariPkg, tobariPkg, chSrc))
-				f.edit.Insert(f.offset(n.End()), ")")
-			}
+			f.edit.Insert(f.offset(n.X.Pos()),
+				fmt.Sprintf("%s_afterRecvChan(", tobariPkg))
+			f.edit.Insert(f.offset(n.X.End()), ")")
 		}
 	case *ast.RangeStmt:
-		// for v := range ch { → insert TraceChan at loop body start
+		// for v := range ch { → for v := range _tobari_afterRecvChan(ch) {
 		if f.funcDep != nil && f.funcDep.ChanRanges != nil {
 			pos := f.fset.Position(n.X.Pos())
 			key := funcPos{Filename: filepath.Clean(pos.Filename), Offset: pos.Offset}
 			if _, ok := f.funcDep.ChanRanges[key]; ok {
-				chSrc := string(f.content[f.offset(n.X.Pos()):f.offset(n.X.End())])
-				f.edit.Insert(f.offset(n.Body.Lbrace)+1,
-					fmt.Sprintf("%s_TraceChan(%s_chanID(%s),%s_GID(),false);", tobariPkg, tobariPkg, chSrc, tobariPkg))
+				f.edit.Insert(f.offset(n.X.Pos()),
+					fmt.Sprintf("%s_afterRecvChan(", tobariPkg))
+				f.edit.Insert(f.offset(n.X.End()), ")")
 			}
 		}
 	}
@@ -654,51 +640,6 @@ func (f *File) createAnonymFuncName(fn *Function) string {
 // collectCommClauseRecvPos pre-scans the AST to find all receive expressions
 // inside CommClause.Comm (select case statements). These positions are used to
 // skip wrapping with afterRecv, since select case syntax does not allow it.
-func collectCommClauseRecvPos(file *ast.File) map[token.Pos]struct{} {
-	pos := make(map[token.Pos]struct{})
-	ast.Inspect(file, func(n ast.Node) bool {
-		cc, ok := n.(*ast.CommClause)
-		if !ok {
-			return true
-		}
-		if cc.Comm == nil {
-			return true
-		}
-		// Collect all receive UnaryExpr positions inside Comm
-		ast.Inspect(cc.Comm, func(inner ast.Node) bool {
-			if ue, ok := inner.(*ast.UnaryExpr); ok && ue.Op == token.ARROW {
-				pos[ue.Pos()] = struct{}{}
-			}
-			return true
-		})
-		return true
-	})
-	return pos
-}
-
-// channelExprFromComm extracts the channel source expression and whether it's a
-// send operation from a CommClause's Comm statement.
-func (f *File) channelExprFromComm(comm ast.Stmt) (string, bool) {
-	if comm == nil {
-		return "", false
-	}
-	switch s := comm.(type) {
-	case *ast.SendStmt:
-		return string(f.content[f.offset(s.Chan.Pos()):f.offset(s.Chan.End())]), true
-	case *ast.ExprStmt:
-		if unary, ok := s.X.(*ast.UnaryExpr); ok && unary.Op == token.ARROW {
-			return string(f.content[f.offset(unary.X.Pos()):f.offset(unary.X.End())]), false
-		}
-	case *ast.AssignStmt:
-		for _, rhs := range s.Rhs {
-			if unary, ok := rhs.(*ast.UnaryExpr); ok && unary.Op == token.ARROW {
-				return string(f.content[f.offset(unary.X.Pos()):f.offset(unary.X.End())]), false
-			}
-		}
-	}
-	return "", false
-}
-
 // findText finds text in the original source, starting at pos.
 // It correctly skips over comments and assumes it need not
 // handle quoted strings.

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -236,6 +236,16 @@ func %[2]s_sendChan[T any](ch chan<- T) chan<- T {
 	return ch
 }
 
+func %[2]s_selectRecv[T any](ch <-chan T, token *uintptr) <-chan T {
+	*token = %[2]s_chanIDRecv(ch)
+	return ch
+}
+
+func %[2]s_selectSend[T any](ch chan<- T, token *uintptr) chan<- T {
+	*token = %[2]s_chanIDSend(ch)
+	return ch
+}
+
 var _ = unsafe.Pointer(nil)
 
 var _ = %[2]s_SetGIDFunc(func() uint64 { return %[2]s_GID() })
@@ -357,6 +367,9 @@ type File struct {
 	funcDep             *FunctionDependency
 	pkgcfg              *PackageConfig
 	anonymGlobalFuncIdx int
+	commClauseCommPos   map[token.Pos]struct{} // positions of CommClause.Comm send/recv to skip wrapping
+	selectInstrumented  map[token.Pos]struct{}
+	selectTokenIdx      int
 }
 
 func (f *File) nextBlockIndex() int {
@@ -404,6 +417,9 @@ func addTracePointWithContent(pkgcfg *PackageConfig, dep *FunctionDependency, fi
 		funcDep:             dep,
 		pkgcfg:              pkgcfg,
 		anonymGlobalFuncIdx: 1,
+		commClauseCommPos:   collectCommClauseCommPos(parsedFile),
+		selectInstrumented:  make(map[token.Pos]struct{}),
+		selectTokenIdx:      1,
 	}
 
 	// Walk the AST and instrument code
@@ -480,12 +496,12 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 					f.addCounters(clause.Colon+1, clause.Colon+1, clause.End(), clause.Body, false)
 				}
 				return f
-				case *ast.CommClause: // select
-					for _, stmt := range n.List {
-						clause := stmt.(*ast.CommClause)
-						f.addCounters(clause.Colon+1, clause.Colon+1, clause.End(), clause.Body, false)
-					}
-					return f
+			case *ast.CommClause: // select
+				for _, stmt := range n.List {
+					clause := stmt.(*ast.CommClause)
+					f.addCounters(clause.Colon+1, clause.Colon+1, clause.End(), clause.Body, false)
+				}
+				return f
 			}
 		}
 		f.addCounters(n.Lbrace, n.Lbrace+1, n.Rbrace+1, n.List, true)
@@ -540,6 +556,17 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 		// Don't annotate an empty select - creates a syntax error.
 		if n.Body == nil || len(n.Body.List) == 0 {
 			return nil
+		}
+		if f.funcDep != nil {
+			if _, ok := f.selectInstrumented[n.Pos()]; !ok {
+				f.instrumentSelect(n, n.Pos())
+			}
+		}
+	case *ast.LabeledStmt:
+		if sel, ok := n.Stmt.(*ast.SelectStmt); ok && f.funcDep != nil {
+			if _, ok := f.selectInstrumented[sel.Pos()]; !ok {
+				f.instrumentSelect(sel, n.Pos())
+			}
 		}
 	case *ast.SwitchStmt:
 		// Don't annotate an empty switch - creates a syntax error.
@@ -602,6 +629,9 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 	case *ast.SendStmt:
 		// ch <- value → _tobari_sendChan(ch) <- value
 		if f.funcDep != nil {
+			if _, skip := f.commClauseCommPos[n.Pos()]; skip {
+				return f
+			}
 			f.edit.Insert(f.offset(n.Chan.Pos()),
 				fmt.Sprintf("%s_sendChan(", tobariPkg))
 			f.edit.Insert(f.offset(n.Chan.End()), ")")
@@ -609,6 +639,9 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 	case *ast.UnaryExpr:
 		// <-ch → <-_tobari_afterRecvChan(ch)
 		if n.Op == token.ARROW && f.funcDep != nil {
+			if _, skip := f.commClauseCommPos[n.Pos()]; skip {
+				return f
+			}
 			f.edit.Insert(f.offset(n.X.Pos()),
 				fmt.Sprintf("%s_afterRecvChan(", tobariPkg))
 			f.edit.Insert(f.offset(n.X.End()), ")")
@@ -637,9 +670,121 @@ func (f *File) createAnonymFuncName(fn *Function) string {
 	return fmt.Sprintf("%s$%d", fn.name, fn.anonymFuncIdx)
 }
 
-// collectCommClauseRecvPos pre-scans the AST to find all receive expressions
+func (f *File) nextSelectToken() string {
+	defer func() { f.selectTokenIdx++ }()
+	return fmt.Sprintf("__tobari_select_id%d", f.selectTokenIdx)
+}
+
+func (f *File) instrumentSelect(n *ast.SelectStmt, insertPos token.Pos) {
+	if n.Body == nil || len(n.Body.List) == 0 {
+		return
+	}
+	f.selectInstrumented[n.Pos()] = struct{}{}
+
+	type caseInfo struct {
+		token  string
+		isSend bool
+		expr   ast.Expr
+		clause *ast.CommClause
+	}
+	var cases []caseInfo
+
+	for _, stmt := range n.Body.List {
+		clause := stmt.(*ast.CommClause)
+		if clause.Comm == nil {
+			continue
+		}
+		expr, isSend := selectCaseChannelExpr(clause.Comm)
+		if expr == nil {
+			continue
+		}
+		cases = append(cases, caseInfo{
+			token:  f.nextSelectToken(),
+			isSend: isSend,
+			expr:   expr,
+			clause: clause,
+		})
+	}
+
+	if len(cases) == 0 {
+		return
+	}
+
+	// Insert token variables before the select statement in source order.
+	for i := 0; i < len(cases); i++ {
+		c := cases[i]
+		f.edit.Insert(f.offset(insertPos), fmt.Sprintf("var %s uintptr;", c.token))
+	}
+
+	// Wrap channel expressions in select cases to record chanID, then trace only when selected.
+	for _, c := range cases {
+		if c.isSend {
+			f.edit.Insert(f.offset(c.expr.Pos()),
+				fmt.Sprintf("%s_selectSend(", tobariPkg))
+			f.edit.Insert(f.offset(c.expr.End()),
+				fmt.Sprintf(",&%s)", c.token))
+			f.edit.Insert(f.offset(c.clause.Colon)+1,
+				fmt.Sprintf("%s_TraceChan(%s,%s_GID(),true);", tobariPkg, c.token, tobariPkg))
+		} else {
+			f.edit.Insert(f.offset(c.expr.Pos()),
+				fmt.Sprintf("%s_selectRecv(", tobariPkg))
+			f.edit.Insert(f.offset(c.expr.End()),
+				fmt.Sprintf(",&%s)", c.token))
+			f.edit.Insert(f.offset(c.clause.Colon)+1,
+				fmt.Sprintf("%s_TraceChan(%s,%s_GID(),false);", tobariPkg, c.token, tobariPkg))
+		}
+	}
+}
+
+func selectCaseChannelExpr(comm ast.Stmt) (ast.Expr, bool) {
+	if comm == nil {
+		return nil, false
+	}
+	switch s := comm.(type) {
+	case *ast.SendStmt:
+		return s.Chan, true
+	case *ast.ExprStmt:
+		if unary, ok := s.X.(*ast.UnaryExpr); ok && unary.Op == token.ARROW {
+			return unary.X, false
+		}
+	case *ast.AssignStmt:
+		for _, rhs := range s.Rhs {
+			if unary, ok := rhs.(*ast.UnaryExpr); ok && unary.Op == token.ARROW {
+				return unary.X, false
+			}
+		}
+	}
+	return nil, false
+}
+
+// collectCommClauseCommPos pre-scans the AST to find all send/recv expressions
 // inside CommClause.Comm (select case statements). These positions are used to
-// skip wrapping with afterRecv, since select case syntax does not allow it.
+// skip wrapping so we can trace only selected cases.
+func collectCommClauseCommPos(file *ast.File) map[token.Pos]struct{} {
+	pos := make(map[token.Pos]struct{})
+	ast.Inspect(file, func(n ast.Node) bool {
+		cc, ok := n.(*ast.CommClause)
+		if !ok {
+			return true
+		}
+		if cc.Comm == nil {
+			return true
+		}
+		// Collect send and receive positions inside Comm
+		ast.Inspect(cc.Comm, func(inner ast.Node) bool {
+			if ss, ok := inner.(*ast.SendStmt); ok {
+				pos[ss.Pos()] = struct{}{}
+			}
+			if ue, ok := inner.(*ast.UnaryExpr); ok && ue.Op == token.ARROW {
+				pos[ue.Pos()] = struct{}{}
+			}
+			return true
+		})
+		return true
+	})
+	return pos
+}
+
 // findText finds text in the original source, starting at pos.
 // It correctly skips over comments and assumes it need not
 // handle quoted strings.

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -410,21 +410,20 @@ var _ = %s_AddCoverMeta(%q)
 func (f *File) renderMetadata() (string, error) {
 	funcs := make([]*tobari.Function, 0, len(f.funcs))
 	for _, fn := range f.funcs {
-		// When "-mod testmain" is specified, funcDep becomes nil, so the process is skipped.
+		// When "-mode testmain" is specified, funcDep becomes nil, so the process is skipped.
 		if f.funcDep == nil {
 			continue
 		}
-		fqdn := f.normalizeFunctionFQDN(fn.name, f.funcDep.PkgPath)
-		depNames := make([]string, 0, len(f.funcDep.DepMap))
-		for name := range f.funcDep.DepMap {
-			depNames = append(depNames, name)
-		}
-		deps, exists := f.funcDep.DepMap[fqdn]
+		deps, exists := f.funcDep.DepMap[fn.name]
 		if !exists {
-			return "", fmt.Errorf("failed to find function dependencies %s from %v", fqdn, depNames)
+			depNames := make([]string, 0, len(f.funcDep.DepMap))
+			for name := range f.funcDep.DepMap {
+				depNames = append(depNames, name)
+			}
+			return "", fmt.Errorf("failed to find function dependencies %s from %v", fn.name, depNames)
 		}
 		funcs = append(funcs, &tobari.Function{
-			Name:   fqdn,
+			Name:   fn.name,
 			Blocks: fn.blocks,
 			Deps:   deps,
 		})
@@ -440,21 +439,6 @@ func (f *File) renderMetadata() (string, error) {
 		return "", fmt.Errorf("failed to encode tobari's metadata: %w", err)
 	}
 	return string(b), nil
-}
-
-func (f *File) normalizeFunctionFQDN(fname, pkgPath string) string {
-	parts := strings.Split(fname, ".")
-
-	if len(parts) == 1 {
-		return fmt.Sprintf("%s.%s", f.funcDep.PkgPath, fname)
-	}
-
-	// method definition.
-	if strings.HasPrefix(parts[0], "*") {
-		// pointer receiver.
-		return fmt.Sprintf("(*%s.%s).%s", pkgPath, parts[0][1:], parts[1])
-	}
-	return fmt.Sprintf("(%s.%s).%s", pkgPath, parts[0], parts[1])
 }
 
 func (f *File) offset(pos token.Pos) int {
@@ -559,17 +543,13 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 		if n.Name.Name == "_" || n.Body == nil {
 			return nil
 		}
-		// Determine proper function or method name.
 		fname := n.Name.Name
-		if r := n.Recv; r != nil && len(r.List) == 1 {
-			t := r.List[0].Type
-			star := ""
-			if p, _ := t.(*ast.StarExpr); p != nil {
-				t = p.X
-				star = "*"
-			}
-			if p, _ := t.(*ast.Ident); p != nil {
-				fname = star + p.Name + "." + fname
+		if f.funcDep != nil && len(f.funcDep.FuncNames) != 0 {
+			// SSA's Function.Pos() returns FuncDecl.Name position (not the func keyword).
+			pos := f.fset.Position(n.Name.Pos())
+			key := funcPos{Filename: filepath.Clean(pos.Filename), Offset: pos.Offset}
+			if fqdn, ok := f.funcDep.FuncNames[key]; ok {
+				fname = fqdn
 			}
 		}
 		parent := f.curFunc
@@ -581,7 +561,15 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 		return nil
 	case *ast.FuncLit:
 		parent := f.curFunc
-		fname := f.createAnonymFuncName(parent)
+		var fname string
+		if f.funcDep != nil && len(f.funcDep.FuncNames) != 0 {
+			pos := f.fset.Position(n.Pos())
+			key := funcPos{Filename: filepath.Clean(pos.Filename), Offset: pos.Offset}
+			fname = f.funcDep.FuncNames[key]
+		}
+		if fname == "" {
+			fname = f.createAnonymFuncName(parent)
+		}
 		fn := newFunction(fname)
 		f.curFunc = fn
 		f.funcs = append(f.funcs, fn)
@@ -597,14 +585,7 @@ func (f *File) createAnonymFuncName(fn *Function) string {
 		defer func() { f.anonymGlobalFuncIdx++ }()
 		return fmt.Sprintf("init$%d", f.anonymGlobalFuncIdx)
 	}
-
 	defer func() { fn.anonymFuncIdx++ }()
-	if fn.name == "init" {
-		// TODO: It is not possible to determine how many other init functions are defined from the information in the current file,
-		// so it is always counted as #1.
-		// This logic will cause issues if there are multiple init functions.
-		return fmt.Sprintf("init#1$%d", fn.anonymFuncIdx)
-	}
 	return fmt.Sprintf("%s$%d", fn.name, fn.anonymFuncIdx)
 }
 

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -193,7 +193,7 @@ func createCovervars(pkgcfg *PackageConfig, pkgcfgPath string, inputFiles []stri
 package %[1]s
 
 import (
-   _ "unsafe"
+   "unsafe"
 )
 
 %[3]s
@@ -214,6 +214,25 @@ func %[2]s_AddCoverMeta(string) bool
 
 //go:linkname %[2]s_AddEmbeddedSource github.com/goccy/tobari/internal/tobari.AddEmbeddedSource
 func %[2]s_AddEmbeddedSource(string, string) bool
+
+//go:linkname %[2]s_TraceChan github.com/goccy/tobari/internal/tobari.TraceChan
+func %[2]s_TraceChan(uintptr, uint64, bool)
+
+func %[2]s_chanID(ch any) uintptr {
+	return (*[2]uintptr)(unsafe.Pointer(&ch))[1]
+}
+
+func %[2]s_afterRecv[T any](chanID uintptr, v T) T {
+	%[2]s_TraceChan(chanID, %[2]s_GID(), false)
+	return v
+}
+
+func %[2]s_beforeSend[T any](chanID uintptr, v T) T {
+	%[2]s_TraceChan(chanID, %[2]s_GID(), true)
+	return v
+}
+
+var _ = unsafe.Pointer(nil)
 
 var _ = %[2]s_SetGIDFunc(func() uint64 { return %[2]s_GID() })
 var _ = func() bool {
@@ -334,6 +353,7 @@ type File struct {
 	funcDep             *FunctionDependency
 	pkgcfg              *PackageConfig
 	anonymGlobalFuncIdx int
+	commClauseRecvPos   map[token.Pos]struct{} // positions of <-ch inside CommClause.Comm to skip wrapping
 }
 
 func (f *File) nextBlockIndex() int {
@@ -381,6 +401,7 @@ func addTracePointWithContent(pkgcfg *PackageConfig, dep *FunctionDependency, fi
 		funcDep:             dep,
 		pkgcfg:              pkgcfg,
 		anonymGlobalFuncIdx: 1,
+		commClauseRecvPos:   collectCommClauseRecvPos(parsedFile),
 	}
 
 	// Walk the AST and instrument code
@@ -460,6 +481,18 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 			case *ast.CommClause: // select
 				for _, stmt := range n.List {
 					clause := stmt.(*ast.CommClause)
+					if f.funcDep != nil {
+						if chSrc, isSend := f.channelExprFromComm(clause.Comm); chSrc != "" {
+							if isSend {
+								// Send in select: wrap value expression via SendStmt case
+								// (handled when the walk visits the SendStmt inside Comm)
+							} else {
+								// Receive in select: insert TraceChan at case body start
+								f.edit.Insert(f.offset(clause.Colon)+1,
+									fmt.Sprintf("%s_TraceChan(%s_chanID(%s),%s_GID(),false);", tobariPkg, tobariPkg, chSrc, tobariPkg))
+							}
+						}
+					}
 					f.addCounters(clause.Colon+1, clause.Colon+1, clause.End(), clause.Body, false)
 				}
 				return f
@@ -576,6 +609,35 @@ func (f *File) Visit(node ast.Node) ast.Visitor {
 		ast.Walk(f, n.Body)
 		f.curFunc = parent
 		return nil
+	case *ast.SendStmt:
+		// ch <- value → ch <- _tobari_beforeSend(chanID, value)
+		if f.funcDep != nil {
+			chSrc := string(f.content[f.offset(n.Chan.Pos()):f.offset(n.Chan.End())])
+			f.edit.Insert(f.offset(n.Value.Pos()),
+				fmt.Sprintf("%s_beforeSend(%s_chanID(%s),", tobariPkg, tobariPkg, chSrc))
+			f.edit.Insert(f.offset(n.Value.End()), ")")
+		}
+	case *ast.UnaryExpr:
+		// <-ch → _tobari_afterRecv(chanID, <-ch)
+		if n.Op == token.ARROW && f.funcDep != nil {
+			if _, skip := f.commClauseRecvPos[n.Pos()]; !skip {
+				chSrc := string(f.content[f.offset(n.X.Pos()):f.offset(n.X.End())])
+				f.edit.Insert(f.offset(n.Pos()),
+					fmt.Sprintf("%s_afterRecv(%s_chanID(%s),", tobariPkg, tobariPkg, chSrc))
+				f.edit.Insert(f.offset(n.End()), ")")
+			}
+		}
+	case *ast.RangeStmt:
+		// for v := range ch { → insert TraceChan at loop body start
+		if f.funcDep != nil && f.funcDep.ChanRanges != nil {
+			pos := f.fset.Position(n.X.Pos())
+			key := funcPos{Filename: filepath.Clean(pos.Filename), Offset: pos.Offset}
+			if _, ok := f.funcDep.ChanRanges[key]; ok {
+				chSrc := string(f.content[f.offset(n.X.Pos()):f.offset(n.X.End())])
+				f.edit.Insert(f.offset(n.Body.Lbrace)+1,
+					fmt.Sprintf("%s_TraceChan(%s_chanID(%s),%s_GID(),false);", tobariPkg, tobariPkg, chSrc, tobariPkg))
+			}
+		}
 	}
 	return f
 }
@@ -587,6 +649,54 @@ func (f *File) createAnonymFuncName(fn *Function) string {
 	}
 	defer func() { fn.anonymFuncIdx++ }()
 	return fmt.Sprintf("%s$%d", fn.name, fn.anonymFuncIdx)
+}
+
+// collectCommClauseRecvPos pre-scans the AST to find all receive expressions
+// inside CommClause.Comm (select case statements). These positions are used to
+// skip wrapping with afterRecv, since select case syntax does not allow it.
+func collectCommClauseRecvPos(file *ast.File) map[token.Pos]struct{} {
+	pos := make(map[token.Pos]struct{})
+	ast.Inspect(file, func(n ast.Node) bool {
+		cc, ok := n.(*ast.CommClause)
+		if !ok {
+			return true
+		}
+		if cc.Comm == nil {
+			return true
+		}
+		// Collect all receive UnaryExpr positions inside Comm
+		ast.Inspect(cc.Comm, func(inner ast.Node) bool {
+			if ue, ok := inner.(*ast.UnaryExpr); ok && ue.Op == token.ARROW {
+				pos[ue.Pos()] = struct{}{}
+			}
+			return true
+		})
+		return true
+	})
+	return pos
+}
+
+// channelExprFromComm extracts the channel source expression and whether it's a
+// send operation from a CommClause's Comm statement.
+func (f *File) channelExprFromComm(comm ast.Stmt) (string, bool) {
+	if comm == nil {
+		return "", false
+	}
+	switch s := comm.(type) {
+	case *ast.SendStmt:
+		return string(f.content[f.offset(s.Chan.Pos()):f.offset(s.Chan.End())]), true
+	case *ast.ExprStmt:
+		if unary, ok := s.X.(*ast.UnaryExpr); ok && unary.Op == token.ARROW {
+			return string(f.content[f.offset(unary.X.Pos()):f.offset(unary.X.End())]), false
+		}
+	case *ast.AssignStmt:
+		for _, rhs := range s.Rhs {
+			if unary, ok := rhs.(*ast.UnaryExpr); ok && unary.Op == token.ARROW {
+				return string(f.content[f.offset(unary.X.Pos()):f.offset(unary.X.End())]), false
+			}
+		}
+	}
+	return "", false
 }
 
 // findText finds text in the original source, starting at pos.
@@ -877,6 +987,7 @@ type edit struct {
 	start   int
 	end     int
 	newText string
+	seq     int
 }
 
 // NewBuffer creates a new edit buffer
@@ -893,6 +1004,7 @@ func (b *Buffer) Insert(offset int, text string) {
 		start:   offset,
 		end:     offset,
 		newText: text,
+		seq:     len(b.edits),
 	})
 }
 
@@ -902,6 +1014,7 @@ func (b *Buffer) Replace(start, end int, newText string) {
 		start:   start,
 		end:     end,
 		newText: newText,
+		seq:     len(b.edits),
 	})
 }
 
@@ -911,9 +1024,14 @@ func (b *Buffer) Bytes() []byte {
 		return b.original
 	}
 
-	// Sort edits by start position (reverse order for correct application)
-	sort.Slice(b.edits, func(i, j int) bool {
-		return b.edits[i].start > b.edits[j].start
+	// Sort edits by start position (reverse order for correct application).
+	// For same-position inserts, later-added edits (higher seq) come first
+	// so they are applied first and end up closer to the original code.
+	sort.SliceStable(b.edits, func(i, j int) bool {
+		if b.edits[i].start != b.edits[j].start {
+			return b.edits[i].start > b.edits[j].start
+		}
+		return b.edits[i].seq > b.edits[j].seq
 	})
 
 	result := make([]byte, len(b.original))

--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -3,6 +3,8 @@ package cover
 import (
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/types"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,10 +29,12 @@ type FunctionDependency struct {
 	DepMap  map[string][]string
 	// FuncNames maps source position → SSA FQDN for all functions in the target package.
 	FuncNames map[funcPos]string
+	// ChanRanges holds positions of range expressions over channels (for v := range ch).
+	ChanRanges map[funcPos]struct{}
 }
 
 func createFunctionDependencyMap(pkgcfg *PackageConfig, path string) (*FunctionDependency, error) {
-	prog, targetPkg, err := getSSAProgram(pkgcfg, path)
+	prog, targetPkg, loadedPkgs, err := getSSAProgram(pkgcfg, path)
 	if err != nil {
 		return nil, err
 	}
@@ -51,14 +55,42 @@ func createFunctionDependencyMap(pkgcfg *PackageConfig, path string) (*FunctionD
 			}] = n.Func.String()
 		}
 	}
+
+	// Detect range-over-channel expressions using type info.
+	chanRanges := make(map[funcPos]struct{})
+	for _, pkg := range loadedPkgs {
+		if pkg.PkgPath != targetPkg.Pkg.Path() {
+			continue
+		}
+		for _, file := range pkg.Syntax {
+			ast.Inspect(file, func(n ast.Node) bool {
+				rs, ok := n.(*ast.RangeStmt)
+				if !ok {
+					return true
+				}
+				if t := pkg.TypesInfo.TypeOf(rs.X); t != nil {
+					if _, ok := t.Underlying().(*types.Chan); ok {
+						pos := prog.Fset.Position(rs.X.Pos())
+						chanRanges[funcPos{
+							Filename: filepath.Clean(pos.Filename),
+							Offset:   pos.Offset,
+						}] = struct{}{}
+					}
+				}
+				return true
+			})
+		}
+	}
+
 	return &FunctionDependency{
-		PkgPath:   targetPkg.Pkg.Path(),
-		DepMap:    depMap,
-		FuncNames: funcNames,
+		PkgPath:    targetPkg.Pkg.Path(),
+		DepMap:     depMap,
+		FuncNames:  funcNames,
+		ChanRanges: chanRanges,
 	}, nil
 }
 
-func getSSAProgram(pkgcfg *PackageConfig, path string) (*ssa.Program, *ssa.Package, error) {
+func getSSAProgram(pkgcfg *PackageConfig, path string) (*ssa.Program, *ssa.Package, []*packages.Package, error) {
 	// Since the results of the `tobari flags` are included in GOFLAGS,
 	// this would result in infinite recursion as is.
 	// Therefore, GOFLAGS is removed from the environment variables.
@@ -83,7 +115,7 @@ func getSSAProgram(pkgcfg *PackageConfig, path string) (*ssa.Program, *ssa.Packa
 
 	pkgs, err := packages.Load(cfg, ".")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	var pkgErrs []error
 	for _, pkg := range pkgs {
@@ -92,7 +124,7 @@ func getSSAProgram(pkgcfg *PackageConfig, path string) (*ssa.Program, *ssa.Packa
 		}
 	}
 	if len(pkgErrs) != 0 {
-		return nil, nil, errors.Join(pkgErrs...)
+		return nil, nil, nil, errors.Join(pkgErrs...)
 	}
 
 	prog, ssaPkgs := ssautil.AllPackages(pkgs, 0)
@@ -108,12 +140,12 @@ func getSSAProgram(pkgcfg *PackageConfig, path string) (*ssa.Program, *ssa.Packa
 		}
 	}
 	if targetPkg == nil {
-		return nil, nil, fmt.Errorf("failed to find target package: %s", pkgcfg.PkgName)
+		return nil, nil, nil, fmt.Errorf("failed to find target package: %s", pkgcfg.PkgName)
 	}
 
 	prog.Build()
 
-	return prog, targetPkg, nil
+	return prog, targetPkg, pkgs, nil
 }
 
 func analyzeFuncDeps(targetPkg *ssa.Package, n *callgraph.Node) []string {

--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -16,9 +16,17 @@ import (
 	"golang.org/x/tools/go/ssa/ssautil"
 )
 
+// funcPos identifies a function by its source position (file + byte offset).
+type funcPos struct {
+	Filename string
+	Offset   int
+}
+
 type FunctionDependency struct {
 	PkgPath string
 	DepMap  map[string][]string
+	// FuncNames maps source position → SSA FQDN for all functions in the target package.
+	FuncNames map[funcPos]string
 }
 
 func createFunctionDependencyMap(pkgcfg *PackageConfig, path string) (*FunctionDependency, error) {
@@ -29,15 +37,24 @@ func createFunctionDependencyMap(pkgcfg *PackageConfig, path string) (*FunctionD
 
 	graph := vta.CallGraph(ssautil.AllFunctions(prog), cha.CallGraph(prog))
 	depMap := make(map[string][]string)
+	funcNames := make(map[funcPos]string)
 	for _, n := range graph.Nodes {
 		if n.Func == nil || n.Func.Pkg != targetPkg {
 			continue
 		}
 		depMap[n.Func.String()] = analyzeFuncDeps(targetPkg, n)
+		if n.Func.Pos().IsValid() {
+			pos := prog.Fset.Position(n.Func.Pos())
+			funcNames[funcPos{
+				Filename: filepath.Clean(pos.Filename),
+				Offset:   pos.Offset,
+			}] = n.Func.String()
+		}
 	}
 	return &FunctionDependency{
-		PkgPath: targetPkg.Pkg.Path(),
-		DepMap:  depMap,
+		PkgPath:   targetPkg.Pkg.Path(),
+		DepMap:    depMap,
+		FuncNames: funcNames,
 	}, nil
 }
 

--- a/internal/tobari/tobari.go
+++ b/internal/tobari/tobari.go
@@ -34,7 +34,7 @@ func ClearCounters() {
 
 	entryMap = make(map[string]*TraceEntry)
 	gMap = make(map[uint64]*TraceG)
-	chanGIDMap = make(map[uintptr][]uint64)
+	chanGIDMap = make(map[uintptr]*chanLinks)
 
 	chanGIDMapMu.Unlock()
 	gMapMu.Unlock()
@@ -321,9 +321,14 @@ var (
 	allCoverprofileMap     map[string]*CoverEntry
 	allCoverprofileMapKeys []string
 	allCoverprofileMapMu   sync.RWMutex
-	chanGIDMap             map[uintptr][]uint64 // channelID → sender GIDs
+	chanGIDMap             map[uintptr]*chanLinks
 	chanGIDMapMu           sync.Mutex
 )
+
+type chanLinks struct {
+	senders   map[uint64]struct{}
+	receivers map[uint64]struct{}
+}
 
 func SetGIDFunc(fn func() uint64) bool {
 	gidFnOnce.Do(func() {
@@ -374,34 +379,82 @@ func TraceChan(chanID uintptr, gid uint64, isSend bool) {
 		return
 	}
 
-	chanGIDMapMu.Lock()
-	defer chanGIDMapMu.Unlock()
-
+	var peers []uint64
 	if isSend {
-		senders := chanGIDMap[chanID]
-		for _, s := range senders {
-			if s == gid {
-				return
+		chanGIDMapMu.Lock()
+		links := chanGIDMap[chanID]
+		if links == nil {
+			links = &chanLinks{
+				senders:   make(map[uint64]struct{}),
+				receivers: make(map[uint64]struct{}),
+			}
+			chanGIDMap[chanID] = links
+		}
+		for recvGID := range links.receivers {
+			if recvGID != gid {
+				peers = append(peers, recvGID)
 			}
 		}
-		chanGIDMap[chanID] = append(senders, gid)
+		links.senders[gid] = struct{}{}
+		chanGIDMapMu.Unlock()
+
+		// Link sender as parent of all known receivers.
+		if len(peers) == 0 {
+			return
+		}
+		gMapMu.Lock()
+		sendG := gMap[gid]
+		if sendG == nil {
+			sendG = newTraceG(gid)
+			gMap[gid] = sendG
+		}
+		for _, recvGID := range peers {
+			recvG := gMap[recvGID]
+			if recvG == nil {
+				recvG = newTraceG(recvGID)
+				gMap[recvGID] = recvG
+			}
+			sendG.linkG(recvG)
+		}
+		gMapMu.Unlock()
 		return
 	}
 
-	// Receive: link this receiver as child of all senders.
-	gMapMu.Lock()
-	g := gMap[gid]
-	if g == nil {
-		g = newTraceG(gid)
-		gMap[gid] = g
+	// Receive: snapshot senders, then link under gMapMu to avoid lock ordering issues.
+	chanGIDMapMu.Lock()
+	links := chanGIDMap[chanID]
+	if links == nil {
+		links = &chanLinks{
+			senders:   make(map[uint64]struct{}),
+			receivers: make(map[uint64]struct{}),
+		}
+		chanGIDMap[chanID] = links
 	}
-	for _, sendGID := range chanGIDMap[chanID] {
-		if sendGID == gid {
-			continue
+	for sendGID := range links.senders {
+		if sendGID != gid {
+			peers = append(peers, sendGID)
 		}
-		if sendG := gMap[sendGID]; sendG != nil {
-			sendG.linkG(g)
+	}
+	links.receivers[gid] = struct{}{}
+	chanGIDMapMu.Unlock()
+
+	// Link this receiver as child of all known senders.
+	if len(peers) == 0 {
+		return
+	}
+	gMapMu.Lock()
+	recvG := gMap[gid]
+	if recvG == nil {
+		recvG = newTraceG(gid)
+		gMap[gid] = recvG
+	}
+	for _, sendGID := range peers {
+		sendG := gMap[sendGID]
+		if sendG == nil {
+			sendG = newTraceG(sendGID)
+			gMap[sendGID] = sendG
 		}
+		sendG.linkG(recvG)
 	}
 	gMapMu.Unlock()
 }
@@ -478,7 +531,7 @@ func initMap() {
 		blockMap = make(map[string]*Block)
 		funcMap = make(map[string]*Function)
 		allCoverprofileMap = make(map[string]*CoverEntry)
-		chanGIDMap = make(map[uintptr][]uint64)
+		chanGIDMap = make(map[uintptr]*chanLinks)
 	})
 }
 

--- a/internal/tobari/tobari.go
+++ b/internal/tobari/tobari.go
@@ -29,15 +29,15 @@ func DisableCoverageCounting() {
 
 func ClearCounters() {
 	entryMapMu.Lock()
-	gMapMu.Lock()
 	chanGIDMapMu.Lock()
+	gMapMu.Lock()
 
 	entryMap = make(map[string]*TraceEntry)
 	gMap = make(map[uint64]*TraceG)
 	chanGIDMap = make(map[uintptr]*chanLinks)
 
-	chanGIDMapMu.Unlock()
 	gMapMu.Unlock()
+	chanGIDMapMu.Unlock()
 	entryMapMu.Unlock()
 }
 
@@ -514,17 +514,17 @@ func init() {
 func initMap() {
 	initOnce.Do(func() {
 		entryMapMu.Lock()
+		chanGIDMapMu.Lock()
 		gMapMu.Lock()
 		blockMapMu.Lock()
 		funcMapMu.Lock()
 		allCoverprofileMapMu.Lock()
-		chanGIDMapMu.Lock()
 		defer entryMapMu.Unlock()
+		defer chanGIDMapMu.Unlock()
 		defer gMapMu.Unlock()
 		defer blockMapMu.Unlock()
 		defer funcMapMu.Unlock()
 		defer allCoverprofileMapMu.Unlock()
-		defer chanGIDMapMu.Unlock()
 
 		entryMap = make(map[string]*TraceEntry)
 		gMap = make(map[uint64]*TraceG)

--- a/internal/tobari/tobari.go
+++ b/internal/tobari/tobari.go
@@ -30,10 +30,13 @@ func DisableCoverageCounting() {
 func ClearCounters() {
 	entryMapMu.Lock()
 	gMapMu.Lock()
+	chanGIDMapMu.Lock()
 
 	entryMap = make(map[string]*TraceEntry)
 	gMap = make(map[uint64]*TraceG)
+	chanGIDMap = make(map[uintptr][]uint64)
 
+	chanGIDMapMu.Unlock()
 	gMapMu.Unlock()
 	entryMapMu.Unlock()
 }
@@ -107,7 +110,7 @@ func WriteAllCoverprofile(mode string, w io.Writer) {
 
 	blockToCountMap := make(map[string]int)
 	for _, g := range gMap {
-		g.blockToCountMap(blockToCountMap)
+		g.blockToCountMap(blockToCountMap, make(map[uint64]struct{}))
 	}
 
 	newCoverprofileMap := make(map[string]*CoverEntry)
@@ -182,7 +185,7 @@ func (e *CoverEntry) String() string {
 func (e *TraceEntry) CoverprofileMap() map[string]*CoverEntry {
 	blockToCountMap := make(map[string]int)
 	for _, root := range e.Roots {
-		root.blockToCountMap(blockToCountMap)
+		root.blockToCountMap(blockToCountMap, make(map[uint64]struct{}))
 	}
 
 	newCoverprofileMap := make(map[string]*CoverEntry)
@@ -282,15 +285,20 @@ func (g *TraceG) linkG(child *TraceG) {
 	g.Children = append(g.Children, child)
 }
 
-func (g *TraceG) blockToCountMap(blockToCountMap map[string]int) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+func (g *TraceG) blockToCountMap(blockToCountMap map[string]int, visited map[uint64]struct{}) {
+	if _, ok := visited[g.ID]; ok {
+		return
+	}
+	visited[g.ID] = struct{}{}
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 
 	for blockID, count := range g.BlockCounterMap {
 		blockToCountMap[blockID] += count
 	}
 	for _, child := range g.Children {
-		child.blockToCountMap(blockToCountMap)
+		child.blockToCountMap(blockToCountMap, visited)
 	}
 }
 
@@ -313,6 +321,8 @@ var (
 	allCoverprofileMap     map[string]*CoverEntry
 	allCoverprofileMapKeys []string
 	allCoverprofileMapMu   sync.RWMutex
+	chanGIDMap             map[uintptr][]uint64 // channelID → sender GIDs
+	chanGIDMapMu           sync.Mutex
 )
 
 func SetGIDFunc(fn func() uint64) bool {
@@ -346,6 +356,54 @@ func getBlock(blockID string) *Block {
 	defer blockMapMu.RUnlock()
 
 	return blockMap[blockID]
+}
+
+// TraceChan records a channel operation for cross-goroutine coverage linking.
+// chanID is the hchan pointer (extracted via unsafe at the call site).
+// When isSend is true, the goroutine is registered as a sender on the channel.
+// When isSend is false (receive), the receiver is linked as a child of all senders.
+func TraceChan(chanID uintptr, gid uint64, isSend bool) {
+	isEnabledTraceMu.RLock()
+	if !isEnabledTrace {
+		isEnabledTraceMu.RUnlock()
+		return
+	}
+	isEnabledTraceMu.RUnlock()
+
+	if chanID == 0 {
+		return
+	}
+
+	chanGIDMapMu.Lock()
+	defer chanGIDMapMu.Unlock()
+
+	if isSend {
+		senders := chanGIDMap[chanID]
+		for _, s := range senders {
+			if s == gid {
+				return
+			}
+		}
+		chanGIDMap[chanID] = append(senders, gid)
+		return
+	}
+
+	// Receive: link this receiver as child of all senders.
+	gMapMu.Lock()
+	g := gMap[gid]
+	if g == nil {
+		g = newTraceG(gid)
+		gMap[gid] = g
+	}
+	for _, sendGID := range chanGIDMap[chanID] {
+		if sendGID == gid {
+			continue
+		}
+		if sendG := gMap[sendGID]; sendG != nil {
+			sendG.linkG(g)
+		}
+	}
+	gMapMu.Unlock()
 }
 
 func Trace(fileName string, pgid, gid uint64, blockIdx, startLine, endLine, startCol, endCol, numStmts int) {
@@ -407,17 +465,20 @@ func initMap() {
 		blockMapMu.Lock()
 		funcMapMu.Lock()
 		allCoverprofileMapMu.Lock()
+		chanGIDMapMu.Lock()
 		defer entryMapMu.Unlock()
 		defer gMapMu.Unlock()
 		defer blockMapMu.Unlock()
 		defer funcMapMu.Unlock()
 		defer allCoverprofileMapMu.Unlock()
+		defer chanGIDMapMu.Unlock()
 
 		entryMap = make(map[string]*TraceEntry)
 		gMap = make(map[uint64]*TraceG)
 		blockMap = make(map[string]*Block)
 		funcMap = make(map[string]*Function)
 		allCoverprofileMap = make(map[string]*CoverEntry)
+		chanGIDMap = make(map[uintptr][]uint64)
 	})
 }
 
@@ -714,7 +775,7 @@ func EncodeCounters() ([]byte, error) {
 
 	blockToCountMap := make(map[string]int)
 	for _, g := range gMap {
-		g.blockToCountMap(blockToCountMap)
+		g.blockToCountMap(blockToCountMap, make(map[uint64]struct{}))
 	}
 
 	var allFnCounters []CoverageFuncCounter

--- a/testdata/channel/channel_fan.go
+++ b/testdata/channel/channel_fan.go
@@ -1,0 +1,63 @@
+package main
+
+// Fan-out: init goroutine spawns 3 workers that read from one channel.
+var (
+	fanoutIn  = make(chan int)
+	fanoutOut = make(chan int)
+)
+
+// Range over channel: init goroutine sums values until channel is closed.
+var (
+	rangeCh     = make(chan int)
+	rangeResult = make(chan int)
+)
+
+func init() {
+	for range 3 {
+		go func() {
+			v := <-fanoutIn
+			fanoutOut <- v * v
+		}()
+	}
+	go func() {
+		sum := 0
+		for v := range rangeCh {
+			sum += v
+		}
+		rangeResult <- sum
+	}()
+}
+
+// Request-Response: init goroutine receives a request and sends response.
+type request struct {
+	value  int
+	respCh chan int
+}
+
+var requestCh = make(chan request)
+
+func init() {
+	go func() {
+		req := <-requestCh
+		req.respCh <- req.value + 100
+	}()
+}
+
+func SendFanout(v int) int {
+	fanoutIn <- v
+	return <-fanoutOut
+}
+
+func SendRange(values []int) int {
+	for _, v := range values {
+		rangeCh <- v
+	}
+	close(rangeCh)
+	return <-rangeResult
+}
+
+func SendRequest(v int) int {
+	respCh := make(chan int)
+	requestCh <- request{value: v, respCh: respCh}
+	return <-respCh
+}

--- a/testdata/channel/channel_sync.go
+++ b/testdata/channel/channel_sync.go
@@ -1,0 +1,39 @@
+package main
+
+// Done/signal pattern: init goroutine waits for done, then sends ack.
+var (
+	doneCh = make(chan struct{})
+	ackCh  = make(chan struct{})
+)
+
+// Pipeline: init goroutine receives, adds 1, then multiplies by 2.
+var (
+	pipelineIn  = make(chan int)
+	pipelineMid = make(chan int)
+	pipelineOut = make(chan int)
+)
+
+func init() {
+	go func() {
+		<-doneCh
+		ackCh <- struct{}{}
+	}()
+	go func() {
+		v := <-pipelineIn
+		pipelineMid <- v + 1
+	}()
+	go func() {
+		v := <-pipelineMid
+		pipelineOut <- v * 2
+	}()
+}
+
+func SignalDone() {
+	doneCh <- struct{}{}
+	<-ackCh
+}
+
+func SendPipeline(v int) int {
+	pipelineIn <- v
+	return <-pipelineOut
+}

--- a/testdata/channel/go.mod
+++ b/testdata/channel/go.mod
@@ -1,0 +1,3 @@
+module example.com/channel
+
+go 1.23

--- a/testdata/channel/main.go
+++ b/testdata/channel/main.go
@@ -1,0 +1,73 @@
+package main
+
+import "fmt"
+
+// Unbuffered channel: init goroutine receives, doubles, and sends back.
+var (
+	unbufferedIn  = make(chan int)
+	unbufferedOut = make(chan int)
+)
+
+// Buffered channel: init goroutine waits for signal, reads buffered values, and sums them.
+var (
+	bufferedCh     = make(chan int, 3)
+	bufferedSignal = make(chan struct{})
+	bufferedResult = make(chan int)
+)
+
+func init() {
+	go func() {
+		v := <-unbufferedIn
+		unbufferedOut <- v * 2
+	}()
+	go func() {
+		<-bufferedSignal
+		sum := 0
+		for i := 0; i < 3; i++ {
+			sum += <-bufferedCh
+		}
+		bufferedResult <- sum
+	}()
+}
+
+// Select: init goroutine receives from one of two channels.
+var (
+	selectIntCh  = make(chan int)
+	selectStrCh  = make(chan string)
+	selectResult = make(chan int)
+)
+
+func init() {
+	go func() {
+		select {
+		case v := <-selectIntCh:
+			selectResult <- v * 3
+		case s := <-selectStrCh:
+			selectResult <- len(s)
+		}
+	}()
+}
+
+func SendUnbuffered(v int) int {
+	unbufferedIn <- v
+	return <-unbufferedOut
+}
+
+func SendBuffered(a, b, c int) int {
+	bufferedCh <- a
+	bufferedCh <- b
+	bufferedCh <- c
+	bufferedSignal <- struct{}{}
+	return <-bufferedResult
+}
+
+func SendSelectInt(v int) int {
+	selectIntCh <- v
+	return <-selectResult
+}
+
+func main() {
+	fmt.Println(SendUnbuffered(5))
+	fmt.Println(SendBuffered(1, 2, 3))
+	fmt.Println(SendSelectInt(7))
+}

--- a/testdata/channel/main_test.go
+++ b/testdata/channel/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import "testing"
+
+func TestSendUnbuffered(t *testing.T) {
+	if got := SendUnbuffered(5); got != 10 {
+		t.Errorf("SendUnbuffered(5) = %d, want 10", got)
+	}
+}
+
+func TestSendBuffered(t *testing.T) {
+	if got := SendBuffered(1, 2, 3); got != 6 {
+		t.Errorf("SendBuffered(1, 2, 3) = %d, want 6", got)
+	}
+}
+
+func TestSendSelectInt(t *testing.T) {
+	if got := SendSelectInt(7); got != 21 {
+		t.Errorf("SendSelectInt(7) = %d, want 21", got)
+	}
+}
+
+func TestSignalDone(t *testing.T) {
+	SignalDone()
+}
+
+func TestSendPipeline(t *testing.T) {
+	// (v + 1) * 2 = (4 + 1) * 2 = 10
+	if got := SendPipeline(4); got != 10 {
+		t.Errorf("SendPipeline(4) = %d, want 10", got)
+	}
+}
+
+func TestSendFanout(t *testing.T) {
+	if got := SendFanout(3); got != 9 {
+		t.Errorf("SendFanout(3) = %d, want 9", got)
+	}
+}
+
+func TestSendRange(t *testing.T) {
+	if got := SendRange([]int{1, 2, 3, 4}); got != 10 {
+		t.Errorf("SendRange([1,2,3,4]) = %d, want 10", got)
+	}
+}
+
+func TestSendRequest(t *testing.T) {
+	if got := SendRequest(42); got != 142 {
+		t.Errorf("SendRequest(42) = %d, want 142", got)
+	}
+}

--- a/testdata/channel/side_effect.go
+++ b/testdata/channel/side_effect.go
@@ -1,0 +1,69 @@
+package main
+
+import "sync/atomic"
+
+var (
+	sideSendCh   = make(chan int)
+	sideRecvCh   = make(chan int)
+	sideSelectCh = make(chan int)
+	sideRangeCh  = make(chan int)
+
+	sendCallCount   int32
+	recvCallCount   int32
+	selectCallCount int32
+	rangeCallCount  int32
+)
+
+func resetSideEffects() {
+	atomic.StoreInt32(&sendCallCount, 0)
+	atomic.StoreInt32(&recvCallCount, 0)
+	atomic.StoreInt32(&selectCallCount, 0)
+	atomic.StoreInt32(&rangeCallCount, 0)
+
+	sideSendCh = make(chan int)
+	sideRecvCh = make(chan int)
+	sideSelectCh = make(chan int)
+	sideRangeCh = make(chan int)
+}
+
+func nextSendChan() chan int {
+	atomic.AddInt32(&sendCallCount, 1)
+	return sideSendCh
+}
+
+func nextRecvChan() chan int {
+	atomic.AddInt32(&recvCallCount, 1)
+	return sideRecvCh
+}
+
+func nextSelectChan() chan int {
+	atomic.AddInt32(&selectCallCount, 1)
+	return sideSelectCh
+}
+
+func nextRangeChan() chan int {
+	atomic.AddInt32(&rangeCallCount, 1)
+	return sideRangeCh
+}
+
+func SendWithSideEffect(v int) {
+	nextSendChan() <- v
+}
+
+func RecvWithSideEffect() int {
+	return <-nextRecvChan()
+}
+
+func SelectRecvWithSideEffect() {
+	select {
+	case <-nextSelectChan():
+	}
+}
+
+func RangeWithSideEffect() int {
+	sum := 0
+	for v := range nextRangeChan() {
+		sum += v
+	}
+	return sum
+}

--- a/testdata/channel/side_effect.go
+++ b/testdata/channel/side_effect.go
@@ -3,15 +3,17 @@ package main
 import "sync/atomic"
 
 var (
-	sideSendCh   = make(chan int)
-	sideRecvCh   = make(chan int)
-	sideSelectCh = make(chan int)
-	sideRangeCh  = make(chan int)
+	sideSendCh       = make(chan int)
+	sideRecvCh       = make(chan int)
+	sideSelectCh     = make(chan int)
+	sideRangeCh      = make(chan int)
+	sideSelectSendCh = make(chan int)
 
-	sendCallCount   int32
-	recvCallCount   int32
-	selectCallCount int32
-	rangeCallCount  int32
+	sendCallCount       int32
+	recvCallCount       int32
+	selectCallCount     int32
+	rangeCallCount      int32
+	selectSendCallCount int32
 )
 
 func resetSideEffects() {
@@ -19,11 +21,13 @@ func resetSideEffects() {
 	atomic.StoreInt32(&recvCallCount, 0)
 	atomic.StoreInt32(&selectCallCount, 0)
 	atomic.StoreInt32(&rangeCallCount, 0)
+	atomic.StoreInt32(&selectSendCallCount, 0)
 
 	sideSendCh = make(chan int)
 	sideRecvCh = make(chan int)
 	sideSelectCh = make(chan int)
 	sideRangeCh = make(chan int)
+	sideSelectSendCh = make(chan int)
 }
 
 func nextSendChan() chan int {
@@ -39,6 +43,11 @@ func nextRecvChan() chan int {
 func nextSelectChan() chan int {
 	atomic.AddInt32(&selectCallCount, 1)
 	return sideSelectCh
+}
+
+func nextSelectSendChan() chan int {
+	atomic.AddInt32(&selectSendCallCount, 1)
+	return sideSelectSendCh
 }
 
 func nextRangeChan() chan int {
@@ -57,6 +66,12 @@ func RecvWithSideEffect() int {
 func SelectRecvWithSideEffect() {
 	select {
 	case <-nextSelectChan():
+	}
+}
+
+func SelectSendWithSideEffect() {
+	select {
+	case nextSelectSendChan() <- 1:
 	}
 }
 

--- a/testdata/channel/side_effect_test.go
+++ b/testdata/channel/side_effect_test.go
@@ -44,6 +44,21 @@ func TestChannelExprSelectRecvEvaluatedOnce(t *testing.T) {
 	}
 }
 
+func TestChannelExprSelectSendEvaluatedOnce(t *testing.T) {
+	resetSideEffects()
+	done := make(chan struct{})
+	go func() {
+		<-sideSelectSendCh
+		close(done)
+	}()
+	SelectSendWithSideEffect()
+	<-done
+
+	if got := atomic.LoadInt32(&selectSendCallCount); got != 1 {
+		t.Fatalf("select send channel expression evaluated %d times, want 1", got)
+	}
+}
+
 func TestChannelExprRangeEvaluatedOnce(t *testing.T) {
 	resetSideEffects()
 	go func() {

--- a/testdata/channel/side_effect_test.go
+++ b/testdata/channel/side_effect_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestChannelExprSendEvaluatedOnce(t *testing.T) {
+	resetSideEffects()
+	done := make(chan struct{})
+	go func() {
+		<-sideSendCh
+		close(done)
+	}()
+	SendWithSideEffect(1)
+	<-done
+
+	if got := atomic.LoadInt32(&sendCallCount); got != 1 {
+		t.Fatalf("send channel expression evaluated %d times, want 1", got)
+	}
+}
+
+func TestChannelExprRecvEvaluatedOnce(t *testing.T) {
+	resetSideEffects()
+	go func() {
+		sideRecvCh <- 1
+	}()
+	_ = RecvWithSideEffect()
+
+	if got := atomic.LoadInt32(&recvCallCount); got != 1 {
+		t.Fatalf("recv channel expression evaluated %d times, want 1", got)
+	}
+}
+
+func TestChannelExprSelectRecvEvaluatedOnce(t *testing.T) {
+	resetSideEffects()
+	go func() {
+		sideSelectCh <- 1
+	}()
+	SelectRecvWithSideEffect()
+
+	if got := atomic.LoadInt32(&selectCallCount); got != 1 {
+		t.Fatalf("select recv channel expression evaluated %d times, want 1", got)
+	}
+}
+
+func TestChannelExprRangeEvaluatedOnce(t *testing.T) {
+	resetSideEffects()
+	go func() {
+		sideRangeCh <- 1
+		sideRangeCh <- 2
+		close(sideRangeCh)
+	}()
+	if got := RangeWithSideEffect(); got != 3 {
+		t.Fatalf("RangeWithSideEffect() = %d, want 3", got)
+	}
+	if got := atomic.LoadInt32(&rangeCallCount); got != 1 {
+		t.Fatalf("range channel expression evaluated %d times, want 1", got)
+	}
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -188,6 +188,12 @@ func TestCacheBehavior(t *testing.T) {
 			runDir:   "testdata/toolchain",
 			hasTest:  true,
 		},
+		{
+			name:     "channel",
+			flagsDir: "testdata/channel",
+			runDir:   "testdata/channel",
+			hasTest:  true,
+		},
 	}
 
 	goFlagsEnv := func(tobariFlags []string) []string {


### PR DESCRIPTION
## Summary
- Instrument channel send/receive operations to track coverage across goroutines communicating via channels
- Enable coverage inclusion for goroutines not directly spawned by `go` statements (e.g. `init()` goroutines), as long as they communicate with test goroutines via channels
- Wrap channel operations at the expression level using generic `afterRecv` / `beforeSend` wrapper functions, recording GID mappings via `TraceChan`

### Key changes
- `internal/tobari/tobari.go`: Add `TraceChan` function and `chanGIDMap` for sender/receiver linking, cycle detection via `visited` set for bidirectional channels
- `internal/cover/cover.go`: Instrument `SendStmt` / `UnaryExpr(ARROW)` / `RangeStmt`, skip wrapping for receives inside `CommClause`, stabilize Buffer insert ordering at same offset via `seq` field
- `internal/cover/deps.go`: Detect range-over-channel using `TypesInfo`, add `ChanRanges` map to `FunctionDependency`
- `testdata/channel/`: Add test data covering unbuffered/buffered/fan-out/pipeline/select/range channel patterns

## Test plan
- [x] `TestCacheBehavior/.*/channel` (clean_cache / with_cache) passes
- [x] `TestTobari/http` no regression in existing tests
- [x] `go test ./...` all tests pass
- [x] `make lint` passes