### PR TITLE
Add allcounts and scoped coverage modes

### DIFF
--- a/internal/cli/convert_cmd.go
+++ b/internal/cli/convert_cmd.go
@@ -46,6 +46,9 @@ func (c *CLI) runConvertCmd(_ context.Context, args []string) (e error) {
 	if err := json.Unmarshal(data, &report); err != nil {
 		return fmt.Errorf("failed to parse tobari.json: %w", err)
 	}
+	if report.Metadata.Files == nil {
+		return fmt.Errorf("failed to parse tobari.json: missing metadata")
+	}
 
 	f, err := os.Create(*output)
 	if err != nil {

--- a/internal/cli/html_cmd.go
+++ b/internal/cli/html_cmd.go
@@ -74,11 +74,12 @@ func (c *CLI) runHTMLCmd(ctx context.Context, args []string) error {
 	}
 
 	// tobari.json → interactive HTML report
-	entriesMap, err := parseTobariJSON(data)
+	report, err := parseTobariJSON(data)
 	if err != nil {
 		return fmt.Errorf("failed to parse tobari.json: %w", err)
 	}
-	if err := generateTobarifmtReport(entriesMap, *output, sourceDir); err != nil {
+	entriesMap := expandCoverReport(report)
+	if err := generateTobarifmtReport(report, entriesMap, *output, sourceDir); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(c.stdout, "HTML coverage report written to %s\n", *output); err != nil {
@@ -124,8 +125,8 @@ func (c *CLI) generateCoverprofileHTML(ctx context.Context, coverprofileContent,
 }
 
 // generateTobarifmtReport generates the interactive HTML report from tobari.json data.
-func generateTobarifmtReport(entriesMap map[string][]tobariJSONEntry, output string, sourceDir string) error {
-	filePaths, fileIndexMap := buildFileIndex(entriesMap)
+func generateTobarifmtReport(report *tobari.CoverReport, entriesMap map[string][]tobariJSONEntry, output string, sourceDir string) error {
+	filePaths, fileIndexMap := buildFileIndexFromReport(report)
 	shortNames := shortenFilePaths(filePaths)
 
 	files := make([]*tobarifmtFile, len(filePaths))
@@ -157,7 +158,7 @@ func generateTobarifmtReport(entriesMap map[string][]tobariJSONEntry, output str
 		}
 	}
 
-	td := buildTobarifmtData(entriesMap, files, fileIndexMap)
+	td := buildTobarifmtData(report, entriesMap, files, fileIndexMap)
 
 	outputFile, err := os.Create(output)
 	if err != nil {
@@ -172,11 +173,11 @@ func generateTobarifmtReport(entriesMap map[string][]tobariJSONEntry, output str
 }
 
 type tobariJSONEntry struct {
-	FileName       string        `json:"FileName"`
+	FileName       string         `json:"FileName"`
 	Start          tobariEntryPos `json:"Start"`
 	End            tobariEntryPos `json:"End"`
-	StatementCount int           `json:"StatementCount"`
-	Count          int           `json:"Count"`
+	StatementCount int            `json:"StatementCount"`
+	Count          int            `json:"Count"`
 }
 
 type tobariEntryPos struct {
@@ -215,19 +216,17 @@ func findCoverageColonIndex(line string) int {
 	return -1
 }
 
-// parseTobariJSON auto-detects the tobari.json format (legacy or compact)
-// and returns the entries as a map[string][]tobariJSONEntry.
-func parseTobariJSON(data []byte) (map[string][]tobariJSONEntry, error) {
+// parseTobariJSON parses tobari.json (compact format only)
+// and returns the report.
+func parseTobariJSON(data []byte) (*tobari.CoverReport, error) {
 	var report tobari.CoverReport
-	if err := json.Unmarshal(data, &report); err == nil && report.Metadata.Files != nil {
-		return expandCoverReport(&report), nil
-	}
-
-	var entriesMap map[string][]tobariJSONEntry
-	if err := json.Unmarshal(data, &entriesMap); err != nil {
+	if err := json.Unmarshal(data, &report); err != nil {
 		return nil, fmt.Errorf("failed to decode tobari.json: %w", err)
 	}
-	return entriesMap, nil
+	if report.Metadata.Files == nil {
+		return nil, fmt.Errorf("failed to decode tobari.json: missing metadata")
+	}
+	return &report, nil
 }
 
 // expandCoverReport converts a compact CoverReport to the legacy entry map format.

--- a/internal/cli/html_cmd_test.go
+++ b/internal/cli/html_cmd_test.go
@@ -63,6 +63,7 @@ func createTobariJSON(t *testing.T, dir, srcPath string) string {
 			{Name: "TestAdd", Coverprofile: [][]int{{0, 3}}},
 			{Name: "TestMain", Coverprofile: [][]int{{0, 2}, {1, 1}}},
 		},
+		AllCounts: []int{5, 1},
 	}
 	data, err := json.Marshal(report)
 	if err != nil {
@@ -125,10 +126,11 @@ func TestParseTobariJSON_CompactFormat(t *testing.T) {
 			{"name": "TestB", "coverprofile": [[0, 2], [1, 1]]}
 		]
 	}`)
-	entriesMap, err := parseTobariJSON(data)
+	report, err := parseTobariJSON(data)
 	if err != nil {
 		t.Fatalf("parseTobariJSON() error = %v", err)
 	}
+	entriesMap := expandCoverReport(report)
 	if len(entriesMap) != 2 {
 		t.Fatalf("expected 2 tests, got %d", len(entriesMap))
 	}
@@ -145,31 +147,6 @@ func TestParseTobariJSON_CompactFormat(t *testing.T) {
 	testB := entriesMap["TestB"]
 	if len(testB) != 2 {
 		t.Fatalf("TestB: expected 2 entries, got %d", len(testB))
-	}
-}
-
-func TestParseTobariJSON_LegacyFormat(t *testing.T) {
-	data := []byte(`{
-		"TestA": [
-			{"FileName": "/path/to/main.go", "Start": {"Line": 3, "Column": 24}, "End": {"Line": 5, "Column": 2}, "StatementCount": 1, "Count": 3}
-		],
-		"TestB": [
-			{"FileName": "/path/to/main.go", "Start": {"Line": 7, "Column": 13}, "End": {"Line": 9, "Column": 2}, "StatementCount": 1, "Count": 1}
-		]
-	}`)
-	entriesMap, err := parseTobariJSON(data)
-	if err != nil {
-		t.Fatalf("parseTobariJSON() error = %v", err)
-	}
-	if len(entriesMap) != 2 {
-		t.Fatalf("expected 2 tests, got %d", len(entriesMap))
-	}
-	testA := entriesMap["TestA"]
-	if len(testA) != 1 {
-		t.Fatalf("TestA: expected 1 entry, got %d", len(testA))
-	}
-	if testA[0].FileName != "/path/to/main.go" || testA[0].Count != 3 {
-		t.Errorf("TestA[0]: FileName=%q, Count=%d", testA[0].FileName, testA[0].Count)
 	}
 }
 
@@ -244,15 +221,16 @@ func TestRunHTMLCmd_TobariJSON_MergesCounts(t *testing.T) {
 			Files: []string{srcPath},
 			Entry: []string{"file", "startLine", "startCol", "endLine", "endCol", "stmts"},
 			All: [][]int{
-				{0, 3, 24, 5, 2, 1},   // block 0: add function
-				{0, 7, 13, 9, 2, 1},   // block 1: main function
-				{0, 11, 1, 13, 2, 1},  // block 2: uncovered function (no test covers it)
+				{0, 3, 24, 5, 2, 1},  // block 0: add function
+				{0, 7, 13, 9, 2, 1},  // block 1: main function
+				{0, 11, 1, 13, 2, 1}, // block 2: uncovered function (no test covers it)
 			},
 		},
 		Counts: []*tobari.CoverReportCount{
 			{Name: "TestAdd", Coverprofile: [][]int{{0, 3}}},
 			{Name: "TestMain", Coverprofile: [][]int{{0, 2}, {1, 1}}},
 		},
+		AllCounts: []int{5, 1, 0},
 	}
 	var buf strings.Builder
 	if err := report.WriteCoverprofile(&buf); err != nil {

--- a/internal/cli/tobarifmt_data.go
+++ b/internal/cli/tobarifmt_data.go
@@ -4,21 +4,26 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/goccy/tobari"
 )
 
 // tobarifmtData is the top-level structure serialized as JSON into the HTML.
 type tobarifmtData struct {
-	Tests      []*tobarifmtTest    `json:"tests"`
-	TestTree   []*tobarifmtTestNode    `json:"testTree"`
-	Files      []*tobarifmtFile    `json:"files"`
-	Overlaps   []*tobarifmtOverlapPair `json:"overlaps"`
-	InstrLines map[int][]int  `json:"instrLines"` // fileIndex → all instrumented line numbers (Count >= 0)
+	Tests            []*tobarifmtTest        `json:"tests"`
+	TestTree         []*tobarifmtTestNode    `json:"testTree"`
+	Files            []*tobarifmtFile        `json:"files"`
+	Overlaps         []*tobarifmtOverlapPair `json:"overlaps"`
+	InstrLinesAll    map[int][]int           `json:"instrLinesAll"`    // fileIndex → all instrumented line numbers (from metadata.all)
+	InstrLinesScoped map[int][]int           `json:"instrLinesScoped"` // fileIndex → instrumented line numbers within CoverWithName scope
+	AllCoverage      map[int][]int           `json:"allCoverage"`      // fileIndex → covered line numbers from allcounts
 }
 
 // tobarifmtTest represents a test with line-level coverage (compact representation).
 type tobarifmtTest struct {
 	Name     string        `json:"n"`
 	Coverage map[int][]int `json:"c"` // fileIndex → sorted list of covered line numbers
+	Instr    map[int][]int `json:"i"` // fileIndex → sorted list of instrumented line numbers
 }
 
 // tobarifmtFile represents a source file with its content.
@@ -30,9 +35,9 @@ type tobarifmtFile struct {
 
 // tobarifmtTestNode represents a node in the test name tree.
 type tobarifmtTestNode struct {
-	Name     string      `json:"name"`
-	FullName string      `json:"fullName"`
-	IsLeaf   bool        `json:"isLeaf"`
+	Name     string               `json:"name"`
+	FullName string               `json:"fullName"`
+	IsLeaf   bool                 `json:"isLeaf"`
 	Children []*tobarifmtTestNode `json:"children,omitempty"`
 }
 
@@ -107,6 +112,36 @@ func convertToLineCoverage(entries []tobariJSONEntry, fileIndexMap map[string]in
 
 	result := make(map[int][]int, len(coveredLines))
 	for fi, lines := range coveredLines {
+		sorted := make([]int, 0, len(lines))
+		for line := range lines {
+			sorted = append(sorted, line)
+		}
+		sort.Ints(sorted)
+		result[fi] = sorted
+	}
+	return result
+}
+
+// convertToLineInstrumented converts raw tobariJSONEntry entries to a line-level
+// instrumented map (includes Count=0 entries).
+func convertToLineInstrumented(entries []tobariJSONEntry, fileIndexMap map[string]int) map[int][]int {
+	instrLines := make(map[int]map[int]struct{})
+
+	for _, e := range entries {
+		fi, ok := fileIndexMap[e.FileName]
+		if !ok {
+			continue
+		}
+		if instrLines[fi] == nil {
+			instrLines[fi] = make(map[int]struct{})
+		}
+		for line := e.Start.Line; line <= e.End.Line; line++ {
+			instrLines[fi][line] = struct{}{}
+		}
+	}
+
+	result := make(map[int][]int, len(instrLines))
+	for fi, lines := range instrLines {
 		sorted := make([]int, 0, len(lines))
 		for line := range lines {
 			sorted = append(sorted, line)
@@ -235,7 +270,29 @@ func shortenFilePaths(paths []string) []string {
 
 // collectUncoveredLines determines which lines in each file have coverage entries
 // but are not covered by the given entries.
-func collectAllCoverageLines(entriesMap map[string][]tobariJSONEntry, fileIndexMap map[string]int) map[int]map[int]struct{} {
+func collectAllCoverageLines(report *tobari.CoverReport) map[int]map[int]struct{} {
+	allLines := make(map[int]map[int]struct{})
+	for _, block := range report.Metadata.All {
+		if len(block) != 6 {
+			continue
+		}
+		fileIdx := block[0]
+		if fileIdx < 0 || fileIdx >= len(report.Metadata.Files) {
+			continue
+		}
+		if allLines[fileIdx] == nil {
+			allLines[fileIdx] = make(map[int]struct{})
+		}
+		startLine := block[1]
+		endLine := block[3]
+		for line := startLine; line <= endLine; line++ {
+			allLines[fileIdx][line] = struct{}{}
+		}
+	}
+	return allLines
+}
+
+func collectScopedCoverageLines(entriesMap map[string][]tobariJSONEntry, fileIndexMap map[string]int) map[int]map[int]struct{} {
 	allLines := make(map[int]map[int]struct{})
 	for _, entries := range entriesMap {
 		for _, e := range entries {
@@ -254,8 +311,46 @@ func collectAllCoverageLines(entriesMap map[string][]tobariJSONEntry, fileIndexM
 	return allLines
 }
 
+func buildAllCoverage(report *tobari.CoverReport) map[int][]int {
+	if len(report.AllCounts) != len(report.Metadata.All) {
+		return nil
+	}
+	covered := make(map[int]map[int]struct{})
+	for i, block := range report.Metadata.All {
+		if len(block) != 6 {
+			continue
+		}
+		if i < 0 || i >= len(report.AllCounts) || report.AllCounts[i] <= 0 {
+			continue
+		}
+		fileIdx := block[0]
+		if fileIdx < 0 || fileIdx >= len(report.Metadata.Files) {
+			continue
+		}
+		if covered[fileIdx] == nil {
+			covered[fileIdx] = make(map[int]struct{})
+		}
+		startLine := block[1]
+		endLine := block[3]
+		for line := startLine; line <= endLine; line++ {
+			covered[fileIdx][line] = struct{}{}
+		}
+	}
+
+	result := make(map[int][]int, len(covered))
+	for fi, lineSet := range covered {
+		sorted := make([]int, 0, len(lineSet))
+		for line := range lineSet {
+			sorted = append(sorted, line)
+		}
+		sort.Ints(sorted)
+		result[fi] = sorted
+	}
+	return result
+}
+
 // buildTobarifmtData constructs the tobarifmtData from parsed tobari.json entries and source files.
-func buildTobarifmtData(entriesMap map[string][]tobariJSONEntry, files []*tobarifmtFile, fileIndexMap map[string]int) *tobarifmtData {
+func buildTobarifmtData(report *tobari.CoverReport, entriesMap map[string][]tobariJSONEntry, files []*tobarifmtFile, fileIndexMap map[string]int) *tobarifmtData {
 	// Build tests with line-level coverage
 	var testNames []string
 	for name := range entriesMap {
@@ -267,16 +362,19 @@ func buildTobarifmtData(entriesMap map[string][]tobariJSONEntry, files []*tobari
 	for _, name := range testNames {
 		entries := entriesMap[name]
 		cov := convertToLineCoverage(entries, fileIndexMap)
+		instr := convertToLineInstrumented(entries, fileIndexMap)
 		// Only include non-empty coverage
 		if len(cov) > 0 {
 			tests = append(tests, &tobarifmtTest{
 				Name:     name,
 				Coverage: cov,
+				Instr:    instr,
 			})
 		} else {
 			tests = append(tests, &tobarifmtTest{
 				Name:     name,
 				Coverage: nil,
+				Instr:    instr,
 			})
 		}
 	}
@@ -287,42 +385,49 @@ func buildTobarifmtData(entriesMap map[string][]tobariJSONEntry, files []*tobari
 	// Compute overlaps
 	overlaps := computeOverlaps(entriesMap, fileIndexMap)
 
-	// Compute all instrumented lines per file (lines from any entry, regardless of Count)
-	allInstrLines := collectAllCoverageLines(entriesMap, fileIndexMap)
-	instrLines := make(map[int][]int, len(allInstrLines))
+	// Compute all instrumented lines per file (from metadata.all)
+	allInstrLines := collectAllCoverageLines(report)
+	instrLinesAll := make(map[int][]int, len(allInstrLines))
 	for fi, lineSet := range allInstrLines {
 		sorted := make([]int, 0, len(lineSet))
 		for line := range lineSet {
 			sorted = append(sorted, line)
 		}
 		sort.Ints(sorted)
-		instrLines[fi] = sorted
+		instrLinesAll[fi] = sorted
 	}
 
+	// Compute instrumented lines within CoverWithName scope
+	scopedInstrLines := collectScopedCoverageLines(entriesMap, fileIndexMap)
+	instrLinesScoped := make(map[int][]int, len(scopedInstrLines))
+	for fi, lineSet := range scopedInstrLines {
+		sorted := make([]int, 0, len(lineSet))
+		for line := range lineSet {
+			sorted = append(sorted, line)
+		}
+		sort.Ints(sorted)
+		instrLinesScoped[fi] = sorted
+	}
+
+	// Compute coverage from allcounts (if available)
+	allCoverage := buildAllCoverage(report)
+
 	return &tobarifmtData{
-		Tests:      tests,
-		TestTree:   tree,
-		Files:      files,
-		Overlaps:   overlaps,
-		InstrLines: instrLines,
+		Tests:            tests,
+		TestTree:         tree,
+		Files:            files,
+		Overlaps:         overlaps,
+		InstrLinesAll:    instrLinesAll,
+		InstrLinesScoped: instrLinesScoped,
+		AllCoverage:      allCoverage,
 	}
 }
 
-// buildFileIndex collects unique file paths from all entries and returns
-// the sorted paths and a map from path to index.
-func buildFileIndex(entriesMap map[string][]tobariJSONEntry) ([]string, map[string]int) {
-	pathSet := make(map[string]struct{})
-	for _, entries := range entriesMap {
-		for _, e := range entries {
-			pathSet[e.FileName] = struct{}{}
-		}
-	}
-
-	paths := make([]string, 0, len(pathSet))
-	for p := range pathSet {
-		paths = append(paths, p)
-	}
-	sort.Strings(paths)
+// buildFileIndexFromReport returns file paths in metadata order and
+// a map from path to index.
+func buildFileIndexFromReport(report *tobari.CoverReport) ([]string, map[string]int) {
+	paths := make([]string, len(report.Metadata.Files))
+	copy(paths, report.Metadata.Files)
 
 	indexMap := make(map[string]int, len(paths))
 	for i, p := range paths {
@@ -330,4 +435,3 @@ func buildFileIndex(entriesMap map[string][]tobariJSONEntry) ([]string, map[stri
 	}
 	return paths, indexMap
 }
-

--- a/internal/cli/tobarifmt_html.go
+++ b/internal/cli/tobarifmt_html.go
@@ -95,6 +95,10 @@ a{color:var(--accent);text-decoration:none}
 .test-actions{display:flex;gap:4px;flex-wrap:wrap}
 .test-actions button{flex:1;padding:4px 8px;font-size:11px;border:1px solid var(--border);border-radius:var(--radius);background:var(--bg);cursor:pointer;color:var(--text-secondary);min-width:0}
 .test-actions button:hover{background:var(--bg-secondary)}
+.coverage-mode{display:flex;gap:12px;flex-wrap:wrap}
+.coverage-mode label{font-size:11px;color:var(--text-secondary);display:flex;align-items:center;gap:6px;cursor:pointer}
+.coverage-mode input[type="radio"]{accent-color:var(--accent)}
+.coverage-mode-desc{font-size:11px;color:var(--text-muted);line-height:1.4}
 .test-tree{flex:1;overflow-y:auto;padding:4px 0}
 .test-stats{padding:8px 12px;border-top:1px solid var(--border-light);font-size:11px;color:var(--text-secondary)}
 
@@ -105,6 +109,7 @@ a{color:var(--accent);text-decoration:none}
 .tree-toggle.has-children{cursor:pointer}
 .tree-toggle.has-children:hover{color:var(--text)}
 .tree-checkbox{margin:0 4px 0 0;cursor:pointer;accent-color:var(--accent)}
+.tree-checkbox:disabled{opacity:0.5;cursor:not-allowed}
 .tree-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
 .tree-children{display:none}
 .tree-node.expanded>.tree-children{display:block}
@@ -213,6 +218,11 @@ a{color:var(--accent);text-decoration:none}
           <button id="btn-select-all">Select All</button>
           <button id="btn-deselect-all">Deselect All</button>
         </div>
+        <div class="coverage-mode" id="coverage-mode">
+          <label><input type="radio" name="cov-mode" value="selected" checked> Selected tests</label>
+          <label><input type="radio" name="cov-mode" value="all"> Merge mode (all goroutines)</label>
+        </div>
+        <div class="coverage-mode-desc" id="coverage-mode-desc"></div>
       </div>
       <div class="test-tree" id="test-tree"></div>
       <div class="test-stats" id="test-stats"></div>
@@ -303,13 +313,28 @@ const state = {
   selectedTests: new Set(),
   currentFile: 0,
   compareMode: null, // null or { testA: string, testB: string }
+  coverageMode: 'selected', // 'selected' or 'all'
 };
 
-// Precompute instrumented lines per file from DATA.instrLines (includes Count=0 entries)
-const instrLineSets = {};
-if (DATA.instrLines) {
-  for (const [fi, lines] of Object.entries(DATA.instrLines)) {
-    instrLineSets[fi] = new Set(lines);
+// Precompute instrumented lines per file
+const instrLineSetsAll = {};
+if (DATA.instrLinesAll) {
+  for (const [fi, lines] of Object.entries(DATA.instrLinesAll)) {
+    instrLineSetsAll[fi] = new Set(lines);
+  }
+}
+
+const instrLineSetsScoped = {};
+if (DATA.instrLinesScoped) {
+  for (const [fi, lines] of Object.entries(DATA.instrLinesScoped)) {
+    instrLineSetsScoped[fi] = new Set(lines);
+  }
+}
+
+const allCoverageSets = {};
+if (DATA.allCoverage) {
+  for (const [fi, lines] of Object.entries(DATA.allCoverage)) {
+    allCoverageSets[fi] = new Set(lines);
   }
 }
 
@@ -327,6 +352,7 @@ if (DATA.instrLines) {
   setupOverlapFilters();
   renderSummary();
   updateHeaderBadge();
+  setupCoverageMode();
 
   document.getElementById('btn-exit-compare').addEventListener('click', exitCompareMode);
   document.getElementById('btn-prev-diff').addEventListener('click', () => navigateDiff(-1));
@@ -345,9 +371,56 @@ function setupTabs() {
   });
 }
 
+function setupCoverageMode() {
+  const container = document.getElementById('coverage-mode');
+  if (!container) return;
+  if (!DATA.allCoverage) {
+    container.style.display = 'none';
+    return;
+  }
+
+  const radios = container.querySelectorAll('input[name="cov-mode"]');
+  radios.forEach(r => {
+    r.addEventListener('change', () => {
+      if (!r.checked) return;
+      applyCoverageMode(r.value);
+    });
+  });
+
+  applyCoverageMode('selected');
+}
+
+function applyCoverageMode(mode) {
+  state.coverageMode = mode;
+  const container = document.getElementById('coverage-mode');
+  if (container) {
+    const radios = container.querySelectorAll('input[name="cov-mode"]');
+    radios.forEach(r => {
+      r.checked = (r.value === mode);
+    });
+  }
+
+  const desc = document.getElementById('coverage-mode-desc');
+  if (desc) {
+    desc.textContent = mode === 'all'
+      ? 'Merge mode: all goroutines / all instrumented blocks (equivalent to go cover). Test selection ignored.'
+      : 'Selected tests: coverage within CoverWithName scope only.';
+  }
+
+  if (mode === 'all') {
+    exitCompareMode();
+  }
+
+  updateAllCheckboxes();
+  renderSourceCode();
+  updateStats();
+  updateHeaderBadge();
+}
+
 // ========== Header Badge ==========
 function updateHeaderBadge() {
   const merged = getMergedCoverage();
+  const instrLineSets = getInstrLineSets();
   let totalInstr = 0, totalCov = 0;
   for (const [fi, instrSet] of Object.entries(instrLineSets)) {
     totalInstr += instrSet.size;
@@ -365,12 +438,14 @@ function renderTestTree() {
   renderNodes(DATA.testTree, container, 0);
 
   document.getElementById('btn-select-all').addEventListener('click', () => {
+    if (state.coverageMode === 'all') return;
     DATA.tests.forEach(t => state.selectedTests.add(t.n));
     exitCompareMode();
     updateAllCheckboxes();
     onSelectionChange();
   });
   document.getElementById('btn-deselect-all').addEventListener('click', () => {
+    if (state.coverageMode === 'all') return;
     state.selectedTests.clear();
     exitCompareMode();
     updateAllCheckboxes();
@@ -443,9 +518,13 @@ function toggleNode(node, checked) {
 }
 
 function updateAllCheckboxes() {
+  const disabled = state.coverageMode === 'all';
   document.querySelectorAll('.tree-node').forEach(div => {
     const cb = div.querySelector(':scope > .tree-label > .tree-checkbox');
-    if (cb) cb.checked = state.selectedTests.has(div.dataset.fullname);
+    if (cb) {
+      cb.checked = state.selectedTests.has(div.dataset.fullname);
+      cb.disabled = disabled;
+    }
   });
 }
 
@@ -483,10 +562,29 @@ function onSelectionChange() {
 
 // ========== Merged Coverage ==========
 function getMergedCoverage() {
+  if (state.coverageMode === 'all' && DATA.allCoverage) {
+    return allCoverageSets;
+  }
   const merged = {};
   DATA.tests.forEach(t => {
     if (!state.selectedTests.has(t.n) || !t.c) return;
     for (const [fi, lines] of Object.entries(t.c)) {
+      if (!merged[fi]) merged[fi] = new Set();
+      lines.forEach(l => merged[fi].add(l));
+    }
+  });
+  return merged;
+}
+
+function getInstrLineSets() {
+  return state.coverageMode === 'all' ? instrLineSetsAll : getSelectedInstrLineSets();
+}
+
+function getSelectedInstrLineSets() {
+  const merged = {};
+  DATA.tests.forEach(t => {
+    if (!state.selectedTests.has(t.n) || !t.i) return;
+    for (const [fi, lines] of Object.entries(t.i)) {
       if (!merged[fi]) merged[fi] = new Set();
       lines.forEach(l => merged[fi].add(l));
     }
@@ -512,9 +610,10 @@ function getTestGroupCoverage(prefix) {
 function buildDiffList(testA, testB) {
   const covA = getTestGroupCoverage(testA);
   const covB = getTestGroupCoverage(testB);
+  const instr = getTestGroupInstrLines(testA, testB);
   const diffs = [];
   DATA.files.forEach((f, fi) => {
-    const instrSet = instrLineSets[fi] || new Set();
+    const instrSet = instr[fi] || new Set();
     const setA = covA[fi] || new Set();
     const setB = covB[fi] || new Set();
     const sortedLines = Array.from(instrSet).sort((a, b) => a - b);
@@ -527,6 +626,19 @@ function buildDiffList(testA, testB) {
     }
   });
   return diffs;
+}
+
+function getTestGroupInstrLines(testA, testB) {
+  const merged = {};
+  DATA.tests.forEach(t => {
+    if (!t.i) return;
+    if (t.n !== testA && !t.n.startsWith(testA + '/') && t.n !== testB && !t.n.startsWith(testB + '/')) return;
+    for (const [fi, lines] of Object.entries(t.i)) {
+      if (!merged[fi]) merged[fi] = new Set();
+      lines.forEach(l => merged[fi].add(l));
+    }
+  });
+  return merged;
 }
 
 function renderDiffBadges() {
@@ -664,6 +776,7 @@ function renderSourceCode() {
   const file = DATA.files[fi];
   if (!file) { container.innerHTML = ''; return; }
 
+  const instrLineSets = getInstrLineSets();
   const instrSet = instrLineSets[fi] || new Set();
 
   // Update file select to show coverage %
@@ -726,6 +839,7 @@ function escapeHTML(s) {
 // ========== Stats ==========
 function updateStats() {
   const merged = getMergedCoverage();
+  const instrLineSets = getInstrLineSets();
   let totalInstr = 0, totalCov = 0;
   for (const [fi, instrSet] of Object.entries(instrLineSets)) {
     totalInstr += instrSet.size;
@@ -733,9 +847,11 @@ function updateStats() {
     for (const l of instrSet) { if (cov.has(l)) totalCov++; }
   }
   const pct = totalInstr > 0 ? (totalCov / totalInstr * 100).toFixed(1) : '0.0';
+  const modeLine = state.coverageMode === 'all'
+    ? 'Mode: All goroutines'
+    : 'Selected: ' + state.selectedTests.size + ' / ' + DATA.tests.length;
   document.getElementById('test-stats').innerHTML =
-    'Selected: ' + state.selectedTests.size + ' / ' + DATA.tests.length +
-    '<br>Coverage: ' + pct + '%';
+    modeLine + '<br>Coverage: ' + pct + '%';
 }
 
 // ========== Overlap Matrix (SVG) ==========
@@ -868,6 +984,7 @@ function setupOverlapFilters() {
 function startCompare(testA, testB) {
   // Select both test groups and enter compare mode
   state.selectedTests.clear();
+  setCoverageModeSelected();
   selectTestAndChildren(testA);
   selectTestAndChildren(testB);
   updateAllCheckboxes();
@@ -875,6 +992,10 @@ function startCompare(testA, testB) {
   updateStats();
   updateHeaderBadge();
   document.querySelector('.tab[data-tab="coverage"]').click();
+}
+
+function setCoverageModeSelected() {
+  applyCoverageMode('selected');
 }
 
 function selectTestAndChildren(prefix) {
@@ -887,17 +1008,10 @@ function selectTestAndChildren(prefix) {
 
 // ========== Summary ==========
 function renderSummary() {
-  const allMerged = {};
-  DATA.tests.forEach(t => {
-    if (!t.c) return;
-    for (const [fi, lines] of Object.entries(t.c)) {
-      if (!allMerged[fi]) allMerged[fi] = new Set();
-      lines.forEach(l => allMerged[fi].add(l));
-    }
-  });
+  const allMerged = getSummaryCoverage();
 
   let totalInstr = 0, totalCov = 0;
-  for (const [fi, instrSet] of Object.entries(instrLineSets)) {
+  for (const [fi, instrSet] of Object.entries(instrLineSetsAll)) {
     totalInstr += instrSet.size;
     const cov = allMerged[fi] || new Set();
     for (const l of instrSet) { if (cov.has(l)) totalCov++; }
@@ -915,7 +1029,7 @@ function renderSummary() {
   fileBody.innerHTML = '';
   const fileRows = [];
   DATA.files.forEach((f, fi) => {
-    const instrSet = instrLineSets[fi] || new Set();
+    const instrSet = instrLineSetsAll[fi] || new Set();
     const cov = allMerged[fi] || new Set();
     let covered = 0;
     for (const l of instrSet) { if (cov.has(l)) covered++; }
@@ -933,30 +1047,34 @@ function renderSummary() {
     fileBody.appendChild(tr);
   });
 
-  // Per-test coverage (top-level)
+  // Per-test coverage (top-level, scoped to each test's instrumented lines)
   const testBody = document.querySelector('#test-coverage-table tbody');
   testBody.innerHTML = '';
   const topLevelMap = {};
   DATA.tests.forEach(t => {
-    if (!t.c) return;
     const topName = t.n.split('/')[0];
-    if (!topLevelMap[topName]) topLevelMap[topName] = new Set();
-    for (const [fi, lines] of Object.entries(t.c)) {
-      lines.forEach(l => topLevelMap[topName].add(fi + ':' + l));
+    if (!topLevelMap[topName]) topLevelMap[topName] = { covered: new Set(), instr: new Set() };
+    if (t.i) {
+      for (const [fi, lines] of Object.entries(t.i)) {
+        lines.forEach(l => topLevelMap[topName].instr.add(fi + ':' + l));
+      }
+    }
+    if (t.c) {
+      for (const [fi, lines] of Object.entries(t.c)) {
+        lines.forEach(l => topLevelMap[topName].covered.add(fi + ':' + l));
+      }
     }
   });
 
   const testRows = [];
-  for (const [name, covSet] of Object.entries(topLevelMap)) {
+  for (const [name, sets] of Object.entries(topLevelMap)) {
+    const total = sets.instr.size;
     let covered = 0;
-    for (const key of covSet) {
-      const sep = key.indexOf(':');
-      const fi = key.substring(0, sep);
-      const line = parseInt(key.substring(sep + 1));
-      const instrSet = instrLineSets[fi];
-      if (instrSet && instrSet.has(line)) covered++;
+    for (const key of sets.covered) {
+      if (sets.instr.has(key)) covered++;
     }
-    testRows.push({ name: name, covered: covered, total: totalInstr, pct: totalInstr > 0 ? covered / totalInstr : 0 });
+    const pct = total > 0 ? covered / total : 0;
+    testRows.push({ name: name, covered: covered, total: total, pct: pct });
   }
   testRows.sort((a, b) => b.pct - a.pct);
   testRows.forEach(r => {
@@ -968,6 +1086,21 @@ function renderSummary() {
       '<td>' + covBarHTML(r.pct) + ' ' + (r.pct * 100).toFixed(1) + '%</td>';
     testBody.appendChild(tr);
   });
+}
+
+function getSummaryCoverage() {
+  if (DATA.allCoverage) {
+    return allCoverageSets;
+  }
+  const merged = {};
+  DATA.tests.forEach(t => {
+    if (!t.c) return;
+    for (const [fi, lines] of Object.entries(t.c)) {
+      if (!merged[fi]) merged[fi] = new Set();
+      lines.forEach(l => merged[fi].add(l));
+    }
+  });
+  return merged;
 }
 
 function covBarHTML(pct) {

--- a/internal/tobari/tobari.go
+++ b/internal/tobari/tobari.go
@@ -610,10 +610,11 @@ func blockID(fileName string, blockIdx int) string {
 
 // CoverReportData holds compact coverage data built from internal state.
 type CoverReportData struct {
-	Files  []string
-	Entry  []string
-	All    [][]int
-	Counts []CoverReportCountData
+	Files     []string
+	Entry     []string
+	All       [][]int
+	Counts    []CoverReportCountData
+	AllCounts []int
 }
 
 // CoverReportCountData holds a test name and its coverage entries.
@@ -646,7 +647,7 @@ func CollectCoverReportData() *CoverReportData {
 
 	// Build block key to index map and "all" array.
 	type blockKey struct {
-		fileIdx  int
+		fileIdx                                        int
 		startLine, startCol, endLine, endCol, numStmts int
 	}
 	blockIndex := make(map[blockKey]int)
@@ -665,6 +666,35 @@ func CollectCoverReportData() *CoverReportData {
 			blockIndex[bk] = len(all)
 			all = append(all, []int{bk.fileIdx, bk.startLine, bk.startCol, bk.endLine, bk.endCol, bk.numStmts})
 		}
+	}
+
+	// Build allcounts from all goroutines.
+	gMapMu.RLock()
+	blockToCountMap := make(map[string]int)
+	for _, g := range gMap {
+		g.blockToCountMap(blockToCountMap, make(map[uint64]struct{}))
+	}
+	gMapMu.RUnlock()
+
+	allCounts := make([]int, len(all))
+	for bid, count := range blockToCountMap {
+		block := getBlock(bid)
+		if block == nil {
+			continue
+		}
+		bk := blockKey{
+			fileIdx:   fileSet[block.FileName],
+			startLine: block.Start.Line,
+			startCol:  block.Start.Col,
+			endLine:   block.End.Line,
+			endCol:    block.End.Col,
+			numStmts:  block.NumStmts,
+		}
+		idx, ok := blockIndex[bk]
+		if !ok {
+			continue
+		}
+		allCounts[idx] = count
 	}
 
 	// Build per-test counts.
@@ -701,10 +731,11 @@ func CollectCoverReportData() *CoverReportData {
 	}
 
 	return &CoverReportData{
-		Files: files,
-		Entry: []string{"FileName", "StartLine", "StartCol", "EndLine", "EndCol", "StatementCount"},
-		All:   all,
-		Counts: counts,
+		Files:     files,
+		Entry:     []string{"FileName", "StartLine", "StartCol", "EndLine", "EndCol", "StatementCount"},
+		All:       all,
+		Counts:    counts,
+		AllCounts: allCounts,
 	}
 }
 
@@ -722,8 +753,9 @@ func MarshalCoverJSON() ([]byte, error) {
 		Coverprofile [][]int `json:"coverprofile"`
 	}
 	type jsonReport struct {
-		Metadata jsonMetadata `json:"metadata"`
-		Counts   []jsonCount  `json:"counts"`
+		Metadata  jsonMetadata `json:"metadata"`
+		Counts    []jsonCount  `json:"counts"`
+		AllCounts []int        `json:"allcounts,omitempty"`
 	}
 	counts := make([]jsonCount, len(data.Counts))
 	for i, c := range data.Counts {
@@ -735,7 +767,8 @@ func MarshalCoverJSON() ([]byte, error) {
 			Entry: data.Entry,
 			All:   data.All,
 		},
-		Counts: counts,
+		Counts:    counts,
+		AllCounts: data.AllCounts,
 	})
 }
 

--- a/tobari.go
+++ b/tobari.go
@@ -182,8 +182,9 @@ func toEntry(e *tobari.CoverEntry) *Entry {
 // The struct mirrors the tobari.json schema directly, so json.Marshal
 // produces the compact format without custom marshaling.
 type CoverReport struct {
-	Metadata CoverReportMetadata `json:"metadata"`
-	Counts   []*CoverReportCount `json:"counts"`
+	Metadata  CoverReportMetadata `json:"metadata"`
+	Counts    []*CoverReportCount `json:"counts"`
+	AllCounts []int               `json:"allcounts,omitempty"`
 }
 
 // CoverReportMetadata contains file names, entry column definitions,
@@ -217,13 +218,15 @@ func CollectCoverReport() *CoverReport {
 			Entry: data.Entry,
 			All:   data.All,
 		},
-		Counts: counts,
+		Counts:    counts,
+		AllCounts: data.AllCounts,
 	}
 }
 
 // WriteCoverprofile writes the merged coverage data in coverprofile format.
 // All blocks from Metadata.All are included; blocks not covered by any test
-// appear with count=0. Counts from all tests are summed per block.
+// appear with count=0. If AllCounts is present, it is used directly;
+// otherwise counts from all tests are summed per block.
 func (r *CoverReport) WriteCoverprofile(w io.Writer) error {
 	type blockEntry struct {
 		key            string
@@ -250,14 +253,22 @@ func (r *CoverReport) WriteCoverprofile(w io.Writer) error {
 		blockByIdx[i] = entry
 	}
 
-	// Overlay counts from each test.
-	for _, c := range r.Counts {
-		for _, cp := range c.Coverprofile {
-			if len(cp) != 2 {
-				continue
+	if len(r.AllCounts) == len(r.Metadata.All) {
+		for i, count := range r.AllCounts {
+			if entry, ok := blockByIdx[i]; ok {
+				entry.count = count
 			}
-			if entry, ok := blockByIdx[cp[0]]; ok {
-				entry.count += cp[1]
+		}
+	} else {
+		// Overlay counts from each test.
+		for _, c := range r.Counts {
+			for _, cp := range c.Coverprofile {
+				if len(cp) != 2 {
+					continue
+				}
+				if entry, ok := blockByIdx[cp[0]]; ok {
+					entry.count += cp[1]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- add top-level allcounts to tobari.json and use it for merged coverprofile output
- compute scoped vs all instrumented line sets and wire them into HTML merge/selected modes
- refine HTML UI/summary to reflect mode semantics and per-test totals

## Testing
- go test ./...
- go test ./internal/cli