### PR TITLE
Add tobari merge command

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -106,6 +106,8 @@ func (c *CLI) handleSubcommand(ctx context.Context, tobariBinPath, cmd string, a
 		return c.runHTMLCmd(ctx, args)
 	case "convert":
 		return c.runConvertCmd(ctx, args)
+	case "merge":
+		return c.runMergeCmd(ctx, args)
 	case "version":
 		return c.showVersion()
 	case "help":

--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -13,6 +13,7 @@ Commands:
     extract     Extract embedded source code from an instrumented binary
     html        Generate HTML coverage report
     convert     Convert tobari.json to coverprofile format
+    merge       Merge multiple tobari.json or source archives
     version     Show version information
     help        Show this help message
 
@@ -35,6 +36,15 @@ HTML Command Options:
 
 Convert Command Options:
     -o <file>           Output coverprofile file path (default: cover.out)
+
+Merge Command:
+    tobari merge json [-o merged.json] <file1.json> <file2.json> [...]
+    tobari merge source [-o merged.tar.gz] <a.tar.gz> <b.tar.gz> [...]
+
+    merge json      Merge multiple tobari.json files into one
+    merge source    Merge multiple source tar.gz archives into one
+                    Duplicate archives (same SHA-256 hash) are skipped.
+                    Conflicting files (same path, different content) cause an error.
 
 Toolexec Options (used with -toolexec):
     --embed-code        Embed original source code into the instrumented binary
@@ -66,6 +76,12 @@ Examples:
 
     # Convert tobari.json to coverprofile
     tobari convert -o profile.cover tobari.json
+
+    # Merge multiple tobari.json files
+    tobari merge json -o merged.json a.json b.json
+
+    # Merge multiple source archives
+    tobari merge source -o merged.tar.gz a.tar.gz b.tar.gz
 
     # Show version
     tobari version

--- a/internal/cli/merge_cmd.go
+++ b/internal/cli/merge_cmd.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/goccy/tobari"
+)
+
+func (c *CLI) runMergeCmd(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing subcommand\nUsage: tobari merge <json|source> [...]")
+	}
+	switch args[0] {
+	case "json":
+		return c.runMergeJSONCmd(ctx, args[1:])
+	case "source":
+		return c.runMergeSourceCmd(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown merge subcommand: %s\nUsage: tobari merge <json|source> [...]", args[0])
+	}
+}
+
+func (c *CLI) runMergeJSONCmd(_ context.Context, args []string) error {
+	fs := flag.NewFlagSet("merge json", flag.ContinueOnError)
+	fs.SetOutput(c.stderr)
+	output := fs.String("o", "merged.json", "output merged tobari.json file path")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 2 {
+		return fmt.Errorf("at least two input files required\nUsage: tobari merge json [-o merged.json] <file1.json> <file2.json> [...]")
+	}
+	for _, arg := range fs.Args() {
+		if strings.HasPrefix(arg, "-") {
+			return fmt.Errorf("flags must be specified before input files\nUsage: tobari merge json [-o merged.json] <file1.json> <file2.json> [...]")
+		}
+	}
+
+	reports := make([]*tobari.CoverReport, 0, fs.NArg())
+	for _, inputFile := range fs.Args() {
+		data, err := os.ReadFile(inputFile)
+		if err != nil {
+			return fmt.Errorf("failed to read input file %s: %w", inputFile, err)
+		}
+		report, err := parseTobariJSON(data)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s: %w", inputFile, err)
+		}
+		reports = append(reports, report)
+	}
+
+	merged, err := tobari.MergeCoverReports(reports)
+	if err != nil {
+		return fmt.Errorf("failed to merge reports: %w", err)
+	}
+
+	mergedData, err := json.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("failed to marshal merged report: %w", err)
+	}
+
+	if err := os.WriteFile(*output, mergedData, 0o644); err != nil {
+		return fmt.Errorf("failed to write output file %s: %w", *output, err)
+	}
+
+	if _, err := fmt.Fprintf(c.stdout, "Merged %d reports into %s\n", len(reports), *output); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CLI) runMergeSourceCmd(_ context.Context, args []string) (e error) {
+	fs := flag.NewFlagSet("merge source", flag.ContinueOnError)
+	fs.SetOutput(c.stderr)
+	output := fs.String("o", "merged.tar.gz", "output merged source archive path")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 2 {
+		return fmt.Errorf("at least two input files required\nUsage: tobari merge source [-o merged.tar.gz] <a.tar.gz> <b.tar.gz> [...]")
+	}
+	for _, arg := range fs.Args() {
+		if strings.HasPrefix(arg, "-") {
+			return fmt.Errorf("flags must be specified before input files\nUsage: tobari merge source [-o merged.tar.gz] <a.tar.gz> <b.tar.gz> [...]")
+		}
+	}
+
+	var openFiles []*os.File
+	defer func() {
+		for _, f := range openFiles {
+			e = errors.Join(e, f.Close())
+		}
+	}()
+
+	inputs := make([]io.Reader, 0, fs.NArg())
+	for _, inputFile := range fs.Args() {
+		f, err := os.Open(inputFile)
+		if err != nil {
+			return fmt.Errorf("failed to open input file %s: %w", inputFile, err)
+		}
+		openFiles = append(openFiles, f)
+		inputs = append(inputs, f)
+	}
+
+	outFile, err := os.Create(*output)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", *output, err)
+	}
+	defer func() { e = errors.Join(e, outFile.Close()) }()
+
+	if err := tobari.MergeCoverArchivedFiles(inputs, outFile); err != nil {
+		return fmt.Errorf("failed to merge source archives: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(c.stdout, "Merged %d source archives into %s\n", fs.NArg(), *output); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cli/merge_cmd_test.go
+++ b/internal/cli/merge_cmd_test.go
@@ -1,0 +1,372 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/tobari"
+)
+
+func TestRunMergeCmd_MissingSubcommand(t *testing.T) {
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeCmd(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "missing subcommand") {
+		t.Errorf("expected missing subcommand error, got: %v", err)
+	}
+}
+
+func TestRunMergeCmd_UnknownSubcommand(t *testing.T) {
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeCmd(context.Background(), []string{"unknown"})
+	if err == nil || !strings.Contains(err.Error(), "unknown merge subcommand") {
+		t.Errorf("expected unknown subcommand error, got: %v", err)
+	}
+}
+
+func TestRunMergeJSONCmd_TooFewInputs(t *testing.T) {
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeJSONCmd(context.Background(), []string{"only-one.json"})
+	if err == nil || !strings.Contains(err.Error(), "at least two input files") {
+		t.Errorf("expected input count error, got: %v", err)
+	}
+}
+
+func TestRunMergeJSONCmd_NonexistentFile(t *testing.T) {
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeJSONCmd(context.Background(), []string{"nonexistent1.json", "nonexistent2.json"})
+	if err == nil || !strings.Contains(err.Error(), "failed to read input file") {
+		t.Errorf("expected file read error, got: %v", err)
+	}
+}
+
+func TestRunMergeJSONCmd_SameSource(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two tobari.json files with same metadata (same server, different tests).
+	report1 := tobari.CoverReport{
+		Metadata: tobari.CoverReportMetadata{
+			Files: []string{"/src/main.go"},
+			Entry: []string{"FileName", "StartLine", "StartCol", "EndLine", "EndCol", "StatementCount"},
+			All:   [][]int{{0, 3, 24, 5, 2, 1}, {0, 7, 13, 9, 2, 1}},
+		},
+		Counts: []*tobari.CoverReportCount{
+			{Name: "TestA", Coverprofile: [][]int{{0, 3}}},
+		},
+		AllCounts: []int{3, 0},
+	}
+	report2 := tobari.CoverReport{
+		Metadata: tobari.CoverReportMetadata{
+			Files: []string{"/src/main.go"},
+			Entry: []string{"FileName", "StartLine", "StartCol", "EndLine", "EndCol", "StatementCount"},
+			All:   [][]int{{0, 3, 24, 5, 2, 1}, {0, 7, 13, 9, 2, 1}},
+		},
+		Counts: []*tobari.CoverReportCount{
+			{Name: "TestB", Coverprofile: [][]int{{1, 2}}},
+		},
+		AllCounts: []int{0, 2},
+	}
+
+	writeJSON(t, dir, "a.json", report1)
+	writeJSON(t, dir, "b.json", report2)
+
+	outputPath := filepath.Join(dir, "merged.json")
+	var stdout bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &bytes.Buffer{}}
+	if err := c.runMergeJSONCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "a.json"),
+		filepath.Join(dir, "b.json"),
+	}); err != nil {
+		t.Fatalf("runMergeJSONCmd() error = %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Merged 2 reports") {
+		t.Errorf("stdout = %q, want to contain success message", stdout.String())
+	}
+
+	// Parse and verify merged result.
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	var merged tobari.CoverReport
+	if err := json.Unmarshal(data, &merged); err != nil {
+		t.Fatalf("failed to parse merged output: %v", err)
+	}
+	if len(merged.Metadata.Files) != 1 || merged.Metadata.Files[0] != "/src/main.go" {
+		t.Errorf("files = %v, want [/src/main.go]", merged.Metadata.Files)
+	}
+	if len(merged.Metadata.All) != 2 {
+		t.Errorf("all blocks = %d, want 2", len(merged.Metadata.All))
+	}
+	if len(merged.Counts) != 2 {
+		t.Errorf("counts = %d, want 2", len(merged.Counts))
+	}
+	if len(merged.AllCounts) != 2 {
+		t.Fatalf("allcounts length = %d, want 2", len(merged.AllCounts))
+	}
+	if merged.AllCounts[0] != 3 || merged.AllCounts[1] != 2 {
+		t.Errorf("allcounts = %v, want [3 2]", merged.AllCounts)
+	}
+}
+
+func TestRunMergeJSONCmd_CrossSource(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two tobari.json files with different metadata (different servers).
+	report1 := tobari.CoverReport{
+		Metadata: tobari.CoverReportMetadata{
+			Files: []string{"/src/server1/main.go"},
+			Entry: []string{"FileName", "StartLine", "StartCol", "EndLine", "EndCol", "StatementCount"},
+			All:   [][]int{{0, 10, 1, 20, 2, 3}},
+		},
+		Counts: []*tobari.CoverReportCount{
+			{Name: "TestS1", Coverprofile: [][]int{{0, 5}}},
+		},
+		AllCounts: []int{5},
+	}
+	report2 := tobari.CoverReport{
+		Metadata: tobari.CoverReportMetadata{
+			Files: []string{"/src/server2/handler.go"},
+			Entry: []string{"FileName", "StartLine", "StartCol", "EndLine", "EndCol", "StatementCount"},
+			All:   [][]int{{0, 5, 1, 15, 2, 2}},
+		},
+		Counts: []*tobari.CoverReportCount{
+			{Name: "TestS2", Coverprofile: [][]int{{0, 7}}},
+		},
+		AllCounts: []int{7},
+	}
+
+	writeJSON(t, dir, "s1.json", report1)
+	writeJSON(t, dir, "s2.json", report2)
+
+	outputPath := filepath.Join(dir, "merged.json")
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	if err := c.runMergeJSONCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "s1.json"),
+		filepath.Join(dir, "s2.json"),
+	}); err != nil {
+		t.Fatalf("runMergeJSONCmd() error = %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	var merged tobari.CoverReport
+	if err := json.Unmarshal(data, &merged); err != nil {
+		t.Fatalf("failed to parse merged output: %v", err)
+	}
+	if len(merged.Metadata.Files) != 2 {
+		t.Errorf("files = %d, want 2", len(merged.Metadata.Files))
+	}
+	if len(merged.Metadata.All) != 2 {
+		t.Errorf("all blocks = %d, want 2", len(merged.Metadata.All))
+	}
+	if len(merged.Counts) != 2 {
+		t.Errorf("counts = %d, want 2", len(merged.Counts))
+	}
+	// Files should be sorted.
+	if merged.Metadata.Files[0] != "/src/server1/main.go" || merged.Metadata.Files[1] != "/src/server2/handler.go" {
+		t.Errorf("files not sorted: %v", merged.Metadata.Files)
+	}
+}
+
+func TestRunMergeSourceCmd_TooFewInputs(t *testing.T) {
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeSourceCmd(context.Background(), []string{"only-one.tar.gz"})
+	if err == nil || !strings.Contains(err.Error(), "at least two input files") {
+		t.Errorf("expected input count error, got: %v", err)
+	}
+}
+
+func TestRunMergeSourceCmd_Success(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two tar.gz archives with different files.
+	createTestTarGz(t, filepath.Join(dir, "a.tar.gz"), map[string]string{
+		"/src/a.go": "package a\n",
+	})
+	createTestTarGz(t, filepath.Join(dir, "b.tar.gz"), map[string]string{
+		"/src/b.go": "package b\n",
+	})
+
+	outputPath := filepath.Join(dir, "merged.tar.gz")
+	var stdout bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &bytes.Buffer{}}
+	if err := c.runMergeSourceCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "a.tar.gz"),
+		filepath.Join(dir, "b.tar.gz"),
+	}); err != nil {
+		t.Fatalf("runMergeSourceCmd() error = %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Merged 2 source archives") {
+		t.Errorf("stdout = %q, want success message", stdout.String())
+	}
+
+	// Verify merged archive.
+	files := readTarGz(t, outputPath)
+	if len(files) != 2 {
+		t.Fatalf("merged archive has %d files, want 2", len(files))
+	}
+	if files["/src/a.go"] != "package a\n" {
+		t.Errorf("a.go content = %q", files["/src/a.go"])
+	}
+	if files["/src/b.go"] != "package b\n" {
+		t.Errorf("b.go content = %q", files["/src/b.go"])
+	}
+}
+
+func TestRunMergeSourceCmd_DuplicateSkip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two identical tar.gz archives.
+	createTestTarGz(t, filepath.Join(dir, "a.tar.gz"), map[string]string{
+		"/src/main.go": "package main\n",
+	})
+	// Copy a.tar.gz to b.tar.gz (identical content).
+	data, err := os.ReadFile(filepath.Join(dir, "a.tar.gz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.tar.gz"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(dir, "merged.tar.gz")
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	if err := c.runMergeSourceCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "a.tar.gz"),
+		filepath.Join(dir, "b.tar.gz"),
+	}); err != nil {
+		t.Fatalf("runMergeSourceCmd() error = %v", err)
+	}
+
+	files := readTarGz(t, outputPath)
+	if len(files) != 1 {
+		t.Errorf("merged archive has %d files, want 1 (duplicate should be skipped)", len(files))
+	}
+}
+
+func TestRunMergeSourceCmd_Conflict(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two archives with same path but different content.
+	createTestTarGz(t, filepath.Join(dir, "a.tar.gz"), map[string]string{
+		"/src/main.go": "package main // version 1\n",
+	})
+	createTestTarGz(t, filepath.Join(dir, "b.tar.gz"), map[string]string{
+		"/src/main.go": "package main // version 2\n",
+	})
+
+	outputPath := filepath.Join(dir, "merged.tar.gz")
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeSourceCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "a.tar.gz"),
+		filepath.Join(dir, "b.tar.gz"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "conflict") {
+		t.Errorf("expected conflict error, got: %v", err)
+	}
+}
+
+// writeJSON writes a CoverReport as JSON to a file in dir.
+func writeJSON(t *testing.T, dir, name string, report tobari.CoverReport) {
+	t.Helper()
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// createTestTarGz creates a tar.gz archive with the given path->content map.
+func createTestTarGz(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(files))
+	for k := range files {
+		keys = append(keys, k)
+	}
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			if keys[i] > keys[j] {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+
+	for _, name := range keys {
+		content := []byte(files[name])
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o600,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// readTarGz reads a tar.gz file and returns path->content map.
+func readTarGz(t *testing.T, path string) map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gr.Close() }()
+
+	result := make(map[string]string)
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(tr); err != nil {
+			t.Fatal(err)
+		}
+		result[hdr.Name] = buf.String()
+	}
+	return result
+}

--- a/tobari.go
+++ b/tobari.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/goccy/tobari/internal/tobari"
 )
@@ -562,9 +561,8 @@ func MergeCoverArchivedFiles(inputs []io.Reader, w io.Writer) error {
 	}
 	sort.Strings(sortedPaths)
 
-	// Write merged tar.gz with deterministic gzip header.
+	// Write merged tar.gz.
 	gw := gzip.NewWriter(w)
-	gw.ModTime = time.Unix(0, 0)
 	tw := tar.NewWriter(gw)
 	for _, p := range sortedPaths {
 		entry := files[p]

--- a/tobari.go
+++ b/tobari.go
@@ -2,7 +2,9 @@ package tobari
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/goccy/tobari/internal/tobari"
 )
@@ -305,6 +308,128 @@ func (r *CoverReport) MarshalTOON() ([]byte, error) {
 	})
 }
 
+// MergeCoverReports merges multiple CoverReport values into a single unified report.
+// File lists and block definitions are unified with deduplication, block indices
+// in Counts are remapped accordingly, and AllCounts are summed per block.
+func MergeCoverReports(reports []*CoverReport) (*CoverReport, error) {
+	if len(reports) == 0 {
+		return nil, fmt.Errorf("no reports to merge")
+	}
+
+	// Build unified sorted file list.
+	fileSet := make(map[string]struct{})
+	for _, r := range reports {
+		for _, f := range r.Metadata.Files {
+			fileSet[f] = struct{}{}
+		}
+	}
+	unifiedFiles := make([]string, 0, len(fileSet))
+	for f := range fileSet {
+		unifiedFiles = append(unifiedFiles, f)
+	}
+	sort.Strings(unifiedFiles)
+
+	fileIndex := make(map[string]int, len(unifiedFiles))
+	for i, f := range unifiedFiles {
+		fileIndex[f] = i
+	}
+
+	// Build unified block list with deduplication.
+	type blockKey struct {
+		fileIdx, startLine, startCol, endLine, endCol, numStmts int
+	}
+	blockMap := make(map[blockKey]int)
+	var unifiedAll [][]int
+
+	// Per-report block index mapping (old block idx -> new block idx).
+	blockMaps := make([]map[int]int, len(reports))
+	for i, r := range reports {
+		blockMaps[i] = make(map[int]int, len(r.Metadata.All))
+		for j, block := range r.Metadata.All {
+			if len(block) != 6 {
+				continue
+			}
+			oldFileIdx := block[0]
+			if oldFileIdx < 0 || oldFileIdx >= len(r.Metadata.Files) {
+				continue
+			}
+			key := blockKey{
+				fileIdx:   fileIndex[r.Metadata.Files[oldFileIdx]],
+				startLine: block[1],
+				startCol:  block[2],
+				endLine:   block[3],
+				endCol:    block[4],
+				numStmts:  block[5],
+			}
+			if newIdx, ok := blockMap[key]; ok {
+				blockMaps[i][j] = newIdx
+			} else {
+				newIdx := len(unifiedAll)
+				blockMap[key] = newIdx
+				unifiedAll = append(unifiedAll, []int{
+					key.fileIdx, key.startLine, key.startCol,
+					key.endLine, key.endCol, key.numStmts,
+				})
+				blockMaps[i][j] = newIdx
+			}
+		}
+	}
+
+	// Remap and concatenate counts.
+	mergedCounts := make([]*CoverReportCount, 0)
+	for i, r := range reports {
+		for _, c := range r.Counts {
+			newProfile := make([][]int, 0, len(c.Coverprofile))
+			for _, cp := range c.Coverprofile {
+				if len(cp) != 2 {
+					continue
+				}
+				if newIdx, ok := blockMaps[i][cp[0]]; ok {
+					newProfile = append(newProfile, []int{newIdx, cp[1]})
+				}
+			}
+			mergedCounts = append(mergedCounts, &CoverReportCount{
+				Name:         c.Name,
+				Coverprofile: newProfile,
+			})
+		}
+	}
+
+	// Compute AllCounts. For each report, use AllCounts if available,
+	// otherwise sum from individual Counts.
+	allCounts := make([]int, len(unifiedAll))
+	for i, r := range reports {
+		if len(r.AllCounts) == len(r.Metadata.All) {
+			for oldIdx, count := range r.AllCounts {
+				if newIdx, ok := blockMaps[i][oldIdx]; ok {
+					allCounts[newIdx] += count
+				}
+			}
+		} else {
+			for _, c := range r.Counts {
+				for _, cp := range c.Coverprofile {
+					if len(cp) != 2 {
+						continue
+					}
+					if newIdx, ok := blockMaps[i][cp[0]]; ok {
+						allCounts[newIdx] += cp[1]
+					}
+				}
+			}
+		}
+	}
+
+	return &CoverReport{
+		Metadata: CoverReportMetadata{
+			Files: unifiedFiles,
+			Entry: reports[0].Metadata.Entry,
+			All:   unifiedAll,
+		},
+		Counts:    mergedCounts,
+		AllCounts: allCounts,
+	}, nil
+}
+
 // ReadCoverArchivedFile extracts the original source files embedded during
 // coverage instrumentation and returns them as a tar.gz archive.
 // Returns nil if no sources were embedded.
@@ -318,12 +443,20 @@ func ReadCoverArchivedFile() io.Reader {
 		return nil
 	}
 
+	// Sort paths for deterministic (idempotent) tar.gz output.
+	paths := make([]string, 0, len(sources))
+	for p := range sources {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
 	pr, pw := io.Pipe()
 	go func() {
 		gw := gzip.NewWriter(pw)
 		tw := tar.NewWriter(gw)
 
-		for origPath, compressed := range sources {
+		for _, origPath := range paths {
+			compressed := sources[origPath]
 			// Decompress from rodata string via strings.NewReader (zero-copy)
 			if err := func() error {
 				gr, err := gzip.NewReader(strings.NewReader(compressed))
@@ -357,4 +490,94 @@ func ReadCoverArchivedFile() io.Reader {
 		pw.CloseWithError(errors.Join(tw.Close(), gw.Close()))
 	}()
 	return pr
+}
+
+// MergeCoverArchivedFiles merges multiple tar.gz source archives into a single archive.
+// Duplicate archives (identical SHA-256 hash) are automatically skipped.
+// If the same file path appears in multiple archives with different content,
+// an error is returned. The output is deterministic: entries are sorted by path
+// and gzip metadata is fixed, so identical inputs always produce identical output.
+func MergeCoverArchivedFiles(inputs []io.Reader, w io.Writer) error {
+	if len(inputs) == 0 {
+		return fmt.Errorf("no inputs to merge")
+	}
+
+	// Read all inputs and deduplicate by SHA-256 hash.
+	seen := make(map[[sha256.Size]byte]struct{})
+	var uniqueData [][]byte
+	for _, r := range inputs {
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return fmt.Errorf("failed to read input: %w", err)
+		}
+		hash := sha256.Sum256(data)
+		if _, ok := seen[hash]; ok {
+			continue
+		}
+		seen[hash] = struct{}{}
+		uniqueData = append(uniqueData, data)
+	}
+
+	// Extract all unique archives and detect conflicts.
+	type fileEntry struct {
+		content []byte
+		hash    [sha256.Size]byte
+	}
+	files := make(map[string]*fileEntry)
+
+	for _, data := range uniqueData {
+		gr, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		tr := tar.NewReader(gr)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("failed to read tar entry: %w", err)
+			}
+			content, err := io.ReadAll(tr)
+			if err != nil {
+				return fmt.Errorf("failed to read content for %s: %w", hdr.Name, err)
+			}
+			contentHash := sha256.Sum256(content)
+			if existing, ok := files[hdr.Name]; ok {
+				if existing.hash != contentHash {
+					return fmt.Errorf("conflict: file %q has different content in source archives", hdr.Name)
+				}
+				continue
+			}
+			files[hdr.Name] = &fileEntry{content: content, hash: contentHash}
+		}
+		_ = gr.Close()
+	}
+
+	// Sort paths for deterministic output.
+	sortedPaths := make([]string, 0, len(files))
+	for p := range files {
+		sortedPaths = append(sortedPaths, p)
+	}
+	sort.Strings(sortedPaths)
+
+	// Write merged tar.gz with deterministic gzip header.
+	gw := gzip.NewWriter(w)
+	gw.Header.ModTime = time.Unix(0, 0)
+	tw := tar.NewWriter(gw)
+	for _, p := range sortedPaths {
+		entry := files[p]
+		if err := tw.WriteHeader(&tar.Header{
+			Name: p,
+			Mode: 0o600,
+			Size: int64(len(entry.content)),
+		}); err != nil {
+			return fmt.Errorf("failed to write header for %s: %w", p, err)
+		}
+		if _, err := tw.Write(entry.content); err != nil {
+			return fmt.Errorf("failed to write content for %s: %w", p, err)
+		}
+	}
+	return errors.Join(tw.Close(), gw.Close())
 }

--- a/tobari.go
+++ b/tobari.go
@@ -564,7 +564,7 @@ func MergeCoverArchivedFiles(inputs []io.Reader, w io.Writer) error {
 
 	// Write merged tar.gz with deterministic gzip header.
 	gw := gzip.NewWriter(w)
-	gw.Header.ModTime = time.Unix(0, 0)
+	gw.ModTime = time.Unix(0, 0)
 	tw := tar.NewWriter(gw)
 	for _, p := range sortedPaths {
 		entry := files[p]

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -561,8 +561,8 @@ func TestMergeCoverArchivedFiles_DeterministicOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read gzip header: %v", err)
 	}
-	if !gr.Header.ModTime.IsZero() {
-		t.Fatalf("gzip header ModTime=%s, want zero time", gr.Header.ModTime)
+	if !gr.ModTime.IsZero() {
+		t.Fatalf("gzip header ModTime=%s, want zero time", gr.ModTime)
 	}
 	_ = gr.Close()
 }

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -2,6 +2,7 @@ package tobari_test
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/tobari"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -521,4 +523,81 @@ func extractAndHashTarGz(t *testing.T, path string) []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+func TestMergeCoverArchivedFiles_DeterministicOutput(t *testing.T) {
+	inputA := createTestTarGzData(t, map[string]string{
+		"/src/main.go":  "package main\n",
+		"/src/util.go":  "package main\n\nfunc util() {}\n",
+		"/README.md":    "example\n",
+		"/LICENSE.txt":  "license\n",
+		"/docs/doc.txt": "doc\n",
+	})
+	inputB := createTestTarGzData(t, map[string]string{
+		"/src/extra.go": "package main\n\nfunc extra() {}\n",
+	})
+
+	var out1 bytes.Buffer
+	if err := tobari.MergeCoverArchivedFiles([]io.Reader{
+		bytes.NewReader(inputA),
+		bytes.NewReader(inputB),
+	}, &out1); err != nil {
+		t.Fatalf("MergeCoverArchivedFiles first run failed: %v", err)
+	}
+
+	var out2 bytes.Buffer
+	if err := tobari.MergeCoverArchivedFiles([]io.Reader{
+		bytes.NewReader(inputA),
+		bytes.NewReader(inputB),
+	}, &out2); err != nil {
+		t.Fatalf("MergeCoverArchivedFiles second run failed: %v", err)
+	}
+
+	if !bytes.Equal(out1.Bytes(), out2.Bytes()) {
+		t.Fatal("merged tar.gz is not deterministic across runs")
+	}
+
+	gr, err := gzip.NewReader(bytes.NewReader(out1.Bytes()))
+	if err != nil {
+		t.Fatalf("failed to read gzip header: %v", err)
+	}
+	if !gr.Header.ModTime.IsZero() {
+		t.Fatalf("gzip header ModTime=%s, want zero time", gr.Header.ModTime)
+	}
+	_ = gr.Close()
+}
+
+func createTestTarGzData(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	keys := make([]string, 0, len(files))
+	for k := range files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, name := range keys {
+		content := []byte(files[name])
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o600,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatalf("write header for %s: %v", name, err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf("write content for %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	return buf.Bytes()
 }

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -556,15 +556,6 @@ func TestMergeCoverArchivedFiles_DeterministicOutput(t *testing.T) {
 	if !bytes.Equal(out1.Bytes(), out2.Bytes()) {
 		t.Fatal("merged tar.gz is not deterministic across runs")
 	}
-
-	gr, err := gzip.NewReader(bytes.NewReader(out1.Bytes()))
-	if err != nil {
-		t.Fatalf("failed to read gzip header: %v", err)
-	}
-	if !gr.ModTime.IsZero() {
-		t.Fatalf("gzip header ModTime=%s, want zero time", gr.ModTime)
-	}
-	_ = gr.Close()
 }
 
 func createTestTarGzData(t *testing.T, files map[string]string) []byte {


### PR DESCRIPTION
## Summary
- Add `tobari merge json` subcommand to merge multiple `tobari.json` coverage reports into a single unified report with deduplicated files/blocks, remapped indices, and summed AllCounts
- Add `tobari merge source` subcommand to merge multiple source tar.gz archives with SHA-256 deduplication and conflict detection
- Make `ReadCoverArchivedFile` output deterministic by sorting paths and stabilizing tar.gz iteration order

## Test plan
- [x] Unit tests for `MergeCoverReports` (same-source and cross-source merging)
- [x] Unit tests for `MergeCoverArchivedFiles` (deterministic output, deduplication)
- [x] CLI tests for `merge json` (missing subcommand, too few inputs, nonexistent file, same-source merge, cross-source merge)
- [x] CLI tests for `merge source` (too few inputs, success, duplicate skip, conflict detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)