### PR TITLE
Add release workflow with GoReleaser and GitHub Artifact Attestations

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,35 @@
+name: Release test
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .goreleaser.yml
+      - .github/workflows/release-test.yml
+  pull_request:
+    paths:
+      - .goreleaser.yml
+      - .github/workflows/release-test.yml
+
+jobs:
+  release-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Run GoReleaser (dry-run)
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --skip=publish --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+            dist/*.rpm
+            dist/*.apk
+            dist/checksums.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,53 @@
+---
+version: 2
+project_name: tobari
+
+builds:
+  - main: ./cmd/tobari
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/goccy/tobari/internal/version.ver=v{{.Version}}
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+
+nfpms:
+  - file_name_template: >-
+      {{ .ProjectName }}_{{ .Version }}-1_{{ .Arch }}
+    homepage: https://github.com/goccy/tobari
+    maintainer: goccy
+    description: Scoped coverage measurement tool for Go
+    license: MIT
+    formats:
+      - deb
+      - rpm
+      - apk
+    bindir: /usr/bin
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  prerelease: auto

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,8 @@ go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0
+	golang.org/x/mod v0.30.0
 	golang.org/x/tools v0.39.0
 )
 
-require (
-	golang.org/x/mod v0.30.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
-)
+require golang.org/x/sync v0.18.0 // indirect

--- a/internal/cli/version_cmd.go
+++ b/internal/cli/version_cmd.go
@@ -2,19 +2,15 @@ package cli
 
 import (
 	"fmt"
-	"runtime/debug"
-	"strings"
+
+	"github.com/goccy/tobari/internal/version"
 )
 
 func (c *CLI) showVersion() error {
-	ver := "(devel)"
-
-	if buildInfo, ok := debug.ReadBuildInfo(); ok {
-		if v := buildInfo.Main.Version; v != "" && strings.HasPrefix(v, "v") {
-			ver = v
-		}
+	v := "(devel)"
+	if ver, err := version.Get(); err == nil && ver.Ver != "" {
+		v = ver.Ver
 	}
-
-	_, err := fmt.Fprintf(c.stdout, "tobari version %s\n", ver)
+	_, err := fmt.Fprintf(c.stdout, "tobari version %s\n", v)
 	return err
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,6 +12,11 @@ import (
 	"strings"
 )
 
+// ver is set at build time via ldflags:
+//
+//	-X github.com/goccy/tobari/internal/version.ver=v0.1.0
+var ver string
+
 type Version struct {
 	Ver       string
 	LocalPath string
@@ -31,6 +36,10 @@ func Get() (*Version, error) {
 	root := repoRoot()
 	if _, err := os.Stat(root); err == nil {
 		return &Version{LocalPath: root}, nil
+	}
+
+	if ver != "" {
+		return &Version{Ver: ver}, nil
 	}
 
 	buildInfo, ok := debug.ReadBuildInfo()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -33,23 +33,28 @@ func (v *Version) ID() string {
 
 // Get determines the version of tobari binary being used.
 func Get() (*Version, error) {
+	if ver != "" {
+		return &Version{Ver: ver}, nil
+	}
+
+	// Prefer tagged/release version when available ( e.g. `go install ...@vX.Y.Z` ),
+	// even if compile-time source path still exists on disk ( module cache ).
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok && buildInfo.Main.Version != "" && !strings.Contains(buildInfo.Main.Version, "devel") {
+		return &Version{Ver: buildInfo.Main.Version}, nil
+	}
+
 	root := repoRoot()
 	if _, err := os.Stat(root); err == nil {
 		return &Version{LocalPath: root}, nil
 	}
 
-	if ver != "" {
-		return &Version{Ver: ver}, nil
-	}
-
-	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
 		return nil, fmt.Errorf("failed to read build info")
 	}
 	if strings.Contains(buildInfo.Main.Version, "devel") {
 		return &Version{Ver: "main"}, nil
 	}
-
 	if buildInfo.Main.Version != "" {
 		return &Version{Ver: buildInfo.Main.Version}, nil
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+
+	"golang.org/x/mod/module"
 )
 
 // ver is set at build time via ldflags:
@@ -39,8 +41,12 @@ func Get() (*Version, error) {
 
 	// Prefer tagged/release version when available ( e.g. `go install ...@vX.Y.Z` ),
 	// even if compile-time source path still exists on disk ( module cache ).
+	// Exclude pseudo-versions (e.g. v0.0.0-20260228130905-0bb47f48a0ec) which
+	// Go 1.25+ stamps into Main.Version for VCS-tracked main-module builds.
 	buildInfo, ok := debug.ReadBuildInfo()
-	if ok && buildInfo.Main.Version != "" && !strings.Contains(buildInfo.Main.Version, "devel") {
+	if ok && buildInfo.Main.Version != "" &&
+		!strings.Contains(buildInfo.Main.Version, "devel") &&
+		!module.IsPseudoVersion(strings.TrimSuffix(buildInfo.Main.Version, "+dirty")) {
 		return &Version{Ver: buildInfo.Main.Version}, nil
 	}
 


### PR DESCRIPTION
## Summary
- Add GoReleaser config and GitHub Actions release workflow triggered on `v*` tag push
- Build tobari binaries for macOS/Linux/Windows (amd64+arm64) with checksums
- Generate deb/rpm/apk packages for Linux via nfpm
- Attest all build artifacts using `actions/attest-build-provenance@v3` for supply chain security
- Add ldflags version injection to `internal/version/version.go` so release binaries report the correct version
- Add release-test workflow to dry-run GoReleaser config on PRs

## Test plan
- [x] `make test` passes with all existing tests
- [ ] Verify `goreleaser release --snapshot --skip=publish --clean` produces expected artifacts in `dist/`
- [ ] After merging and tagging, verify GitHub Releases page shows all assets and attestation

🤖 Generated with [Claude Code](https://claude.com/claude-code)