### PR TITLE
Fix build failure on packages with generic type methods

### DIFF
--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -82,6 +82,27 @@ func createFunctionDependencyMap(pkgcfg *PackageConfig, path string) (*FunctionD
 		}
 	}
 
+	// Add functions/methods missing from the call graph.
+	// This handles generic (parameterized) types whose methods are not
+	// included by ssautil.AllFunctions, as well as any other unreachable
+	// functions that still appear in the source AST.
+	for _, member := range targetPkg.Members {
+		switch m := member.(type) {
+		case *ssa.Function:
+			addMissingFunc(prog, m, depMap, funcNames)
+		case *ssa.Type:
+			named, ok := m.Type().(*types.Named)
+			if !ok {
+				continue
+			}
+			for method := range named.Methods() {
+				if ssaFn := prog.FuncValue(method); ssaFn != nil {
+					addMissingFunc(prog, ssaFn, depMap, funcNames)
+				}
+			}
+		}
+	}
+
 	return &FunctionDependency{
 		PkgPath:    targetPkg.Pkg.Path(),
 		DepMap:     depMap,
@@ -146,6 +167,33 @@ func getSSAProgram(pkgcfg *PackageConfig, path string) (*ssa.Program, *ssa.Packa
 	prog.Build()
 
 	return prog, targetPkg, pkgs, nil
+}
+
+func addMissingFunc(prog *ssa.Program, fn *ssa.Function, depMap map[string][]string, funcNames map[funcPos]string) {
+	if _, exists := depMap[fn.String()]; exists {
+		return
+	}
+	depMap[fn.String()] = nil
+	if fn.Pos().IsValid() {
+		pos := prog.Fset.Position(fn.Pos())
+		funcNames[funcPos{
+			Filename: filepath.Clean(pos.Filename),
+			Offset:   pos.Offset,
+		}] = fn.String()
+	}
+	for _, anon := range fn.AnonFuncs {
+		if _, exists := depMap[anon.String()]; exists {
+			continue
+		}
+		depMap[anon.String()] = nil
+		if anon.Pos().IsValid() {
+			pos := prog.Fset.Position(anon.Pos())
+			funcNames[funcPos{
+				Filename: filepath.Clean(pos.Filename),
+				Offset:   pos.Offset,
+			}] = anon.String()
+		}
+	}
 }
 
 func analyzeFuncDeps(targetPkg *ssa.Package, n *callgraph.Node) []string {

--- a/testdata/generic/go.mod
+++ b/testdata/generic/go.mod
@@ -1,0 +1,3 @@
+module example.com/generic
+
+go 1.23

--- a/testdata/generic/main.go
+++ b/testdata/generic/main.go
@@ -1,0 +1,44 @@
+package main
+
+import "fmt"
+
+type Result[T any] struct {
+	value T
+	err   error
+}
+
+func Ok[T any](value T) Result[T] {
+	return Result[T]{value: value}
+}
+
+func Err[T any](err error) Result[T] {
+	return Result[T]{err: err}
+}
+
+func (r Result[T]) IsOk() bool {
+	return r.err == nil
+}
+
+func (r Result[T]) Unwrap() T {
+	if r.err != nil {
+		panic(r.err)
+	}
+	return r.value
+}
+
+func (r Result[T]) UnwrapOr(def T) T {
+	if r.err != nil {
+		return def
+	}
+	return r.value
+}
+
+func main() {
+	r := Ok(42)
+	fmt.Println(r.IsOk())
+	fmt.Println(r.Unwrap())
+
+	e := Err[string](fmt.Errorf("something went wrong"))
+	fmt.Println(e.IsOk())
+	fmt.Println(e.UnwrapOr("fallback"))
+}

--- a/testdata/generic/main_test.go
+++ b/testdata/generic/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestOk(t *testing.T) {
+	r := Ok(42)
+	if !r.IsOk() {
+		t.Error("expected Ok")
+	}
+	if got := r.Unwrap(); got != 42 {
+		t.Errorf("Unwrap() = %d, want 42", got)
+	}
+}
+
+func TestErr(t *testing.T) {
+	r := Err[int](fmt.Errorf("fail"))
+	if r.IsOk() {
+		t.Error("expected Err")
+	}
+	if got := r.UnwrapOr(99); got != 99 {
+		t.Errorf("UnwrapOr() = %d, want 99", got)
+	}
+}
+
+func TestUnwrapOr(t *testing.T) {
+	r := Ok("hello")
+	if got := r.UnwrapOr("fallback"); got != "hello" {
+		t.Errorf("UnwrapOr() = %q, want %q", got, "hello")
+	}
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -196,6 +196,12 @@ func TestCacheBehavior(t *testing.T) {
 			runDir:   "testdata/channel",
 			hasTest:  true,
 		},
+		{
+			name:     "generic",
+			flagsDir: "testdata/generic",
+			runDir:   "testdata/generic",
+			hasTest:  true,
+		},
 	}
 
 	goFlagsEnv := func(tobariFlags []string) []string {


### PR DESCRIPTION
## Summary

- Fixed a build failure where ssautil.AllFunctions excludes methods of generic types (TypeParams != nil) from the call graph, causing failed to find function dependencies errors during coverage instrumentation
- After building the call graph, iterate targetPkg.Members to supplement FuncNames/DepMap with missing functions and methods
- Added testdata/generic/ with a Result[T] type as a test fixture, and added an entry to TestCacheBehavior to verify that packages containing generic types build
  successfully

## Background

tobari hooks the cover tool via -toolexec and builds function dependency maps using SSA analysis. Previously, FuncNames/DepMap were populated solely from the VTA/CHA call graph built via ssautil.AllFunctions. However, ssautil.AllFunctions intentionally excludes methods of generic types by checking named.TypeParams() == nil in [visit.go's exportedTypeHack](https://github.com/golang/tools/blob/v0.39.0/go/ssa/ssautil/visit.go#L107).
Meanwhile, the AST walker processes all FuncDecl nodes, so it encounters generic type methods that are absent from the maps, resulting in an error.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification