### PR TITLE
Add build tags support via tobari flags -tags option

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/goccy/tobari/internal/tool"
 )
@@ -33,13 +34,23 @@ func (c *CLI) Run(ctx context.Context, args []string) error {
 
 	tobariBinPath := args[0]
 
-	// Detect --embed-code flag for toolexec mode
-	// When invoked as: tobari --embed-code /path/to/compile <args>
+	// Parse tobari-specific flags before the tool path.
+	// When invoked as: tobari [--embed-code] [--build-tags=VALUE] /path/to/compile <args>
 	embedCode := false
-	if len(args) > 1 && args[1] == "--embed-code" {
-		embedCode = true
-		args = append(args[:1], args[2:]...) // remove --embed-code
+	buildTags := ""
+	i := 1
+	for i < len(args) {
+		if args[i] == "--embed-code" {
+			embedCode = true
+			i++
+		} else if strings.HasPrefix(args[i], "--build-tags=") {
+			buildTags = strings.TrimPrefix(args[i], "--build-tags=")
+			i++
+		} else {
+			break
+		}
 	}
+	args = append(args[:1], args[i:]...) // remove consumed flags
 
 	if len(args) < 2 {
 		return c.showHelp()
@@ -50,7 +61,10 @@ func (c *CLI) Run(ctx context.Context, args []string) error {
 	// Check if this is a toolexec call
 	// toolexec passes Go tool's absolute path as args[1]
 	if isToolexecCall(arg1) {
-		return tool.Handle(ctx, args, embedCode)
+		return tool.Handle(ctx, args, tool.BuildOpts{
+			EmbedCode: embedCode,
+			BuildTags: buildTags,
+		})
 	}
 
 	// Handle flags (starts with "-")

--- a/internal/cli/flags_cmd.go
+++ b/internal/cli/flags_cmd.go
@@ -13,17 +13,18 @@ func (c *CLI) runFlagsCmd(ctx context.Context, tobariBinPath string, args []stri
 	fs := flag.NewFlagSet("flags", flag.ContinueOnError)
 	embedCode := fs.Bool("embed-code", false, "embed source code into the instrumented binary")
 	fs.BoolVar(embedCode, "E", false, "embed source code into the instrumented binary (shorthand)")
+	tags := fs.String("tags", "", "build tags (same as go build -tags)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	for _, arg := range fs.Args() {
 		if strings.HasPrefix(arg, "-") {
-			return fmt.Errorf("flags must be specified before other arguments\nUsage: tobari flags [--embed-code | -E]")
+			return fmt.Errorf("flags must be specified before other arguments\nUsage: tobari flags [--embed-code | -E] [-tags=VALUE]")
 		}
 	}
 
-	out, err := flags.Run(ctx, tobariBinPath, *embedCode)
+	out, err := flags.Run(ctx, tobariBinPath, *embedCode, *tags)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -23,6 +23,7 @@ Flags:
 
 Flags Command Options:
     --embed-code, -E    Embed original source code into the instrumented binary
+    -tags=VALUE         Build tags (same as go build -tags)
 
 HTML Command Options:
     -o <file>           Output HTML file path (default: cover.html)
@@ -61,6 +62,9 @@ Examples:
 
     # Use tobari directly as toolexec with source embedding
     go build -cover -toolexec='tobari --embed-code' ./...
+
+    # Use tobari with build tags (e.g., timetzdata)
+    GOFLAGS=$(tobari flags -tags=timetzdata) go build ./...
 
     # Extract embedded sources from an instrumented binary
     tobari extract -o sources.tar.gz ./my-binary

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func Run(ctx context.Context, tobariBinPath string, embedCode bool) (string, error) {
+func Run(ctx context.Context, tobariBinPath string, embedCode bool, tags string) (string, error) {
 	path, err := exec.LookPath(tobariBinPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to find tobari binary path from %s: %w", tobariBinPath, err)
@@ -22,15 +22,20 @@ func Run(ctx context.Context, tobariBinPath string, embedCode bool) (string, err
 	}
 	toolexecValue := path
 	if embedCode {
-		toolexecValue = path + " --embed-code"
+		toolexecValue += " --embed-code"
+	}
+	if tags != "" {
+		toolexecValue += " --build-tags=" + tags
 	}
 	toolexecFlag := "-toolexec=" + toolexecValue
 	if strings.Contains(toolexecValue, " ") {
 		// Quote for GOFLAGS which uses SplitQuotedFields
 		toolexecFlag = "'-toolexec=" + toolexecValue + "'"
 	}
-	return strings.Join([]string{
-		"-cover",
-		toolexecFlag,
-	}, " "), nil
+	parts := []string{"-cover"}
+	if tags != "" {
+		parts = append(parts, "-tags="+tags)
+	}
+	parts = append(parts, toolexecFlag)
+	return strings.Join(parts, " "), nil
 }

--- a/internal/tool/app.go
+++ b/internal/tool/app.go
@@ -13,7 +13,7 @@ import (
 	"github.com/goccy/tobari/internal/version"
 )
 
-func buildPackages(ver *version.Version, lang string, trimpath bool, race bool, embedCode bool) (map[string]string, error) {
+func buildPackages(ver *version.Version, lang string, opts BuildOpts) (map[string]string, error) {
 	appDir := appPath(ver)
 	// Skip createApp if the directory was already prepared by a prior toolexec
 	// invocation.
@@ -23,7 +23,7 @@ func buildPackages(ver *version.Version, lang string, trimpath bool, race bool, 
 		}
 	}
 
-	toolexec, err := tobariToolexec(embedCode)
+	toolexec, err := tobariToolexec(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,12 @@ func buildPackages(ver *version.Version, lang string, trimpath bool, race bool, 
 	// preventing fingerprint mismatches when Go's build cache replays cached results.
 	// When the outer build uses -trimpath, passing -trimpath here ensures the inner
 	// build produces packages in the same cache entries as the outer build.
-	pkgs, err := utils.GoListDepsExport(appDir, toolexec, trimpath, race, "github.com/goccy/tobari")
+	pkgs, err := utils.GoListDepsExport(appDir, utils.GoListOpts{
+		Toolexec:  toolexec,
+		Trimpath:  opts.Trimpath,
+		Race:      opts.Race,
+		BuildTags: opts.BuildTags,
+	}, "github.com/goccy/tobari")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tobari packages: %w", err)
 	}

--- a/internal/tool/build.go
+++ b/internal/tool/build.go
@@ -8,23 +8,27 @@ import (
 	"github.com/goccy/tobari/internal/version"
 )
 
-func tobariToolexec(embedCode bool) (string, error) {
+func tobariToolexec(opts BuildOpts) (string, error) {
 	tobariPath, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("failed to get tobari binary path: %w", err)
 	}
-	if embedCode {
-		return tobariPath + " --embed-code", nil
+	v := tobariPath
+	if opts.EmbedCode {
+		v += " --embed-code"
 	}
-	return tobariPath, nil
+	if opts.BuildTags != "" {
+		v += " --build-tags=" + opts.BuildTags
+	}
+	return v, nil
 }
 
-func getTobariPkgs(args []string, embedCode bool, trimpath bool, race bool) (map[string]string, error) {
+func getTobariPkgs(args []string, opts BuildOpts) (map[string]string, error) {
 	ver, err := version.Get()
 	if err != nil {
 		return nil, err
 	}
-	pkgs, err := buildPackages(ver, getLangFromArgs(args), trimpath, race, embedCode)
+	pkgs, err := buildPackages(ver, getLangFromArgs(args), opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build temp module: %w", err)
 	}

--- a/internal/tool/compile.go
+++ b/internal/tool/compile.go
@@ -11,9 +11,10 @@ import (
 	"github.com/goccy/tobari/internal/utils"
 )
 
-func handleCompile(ctx context.Context, toolPath string, args []string, embedCode bool) error {
-	trimpath := hasExplicitTrimpath(args)
-	race := hasRaceFlag(args)
+func handleCompile(ctx context.Context, toolPath string, args []string, opts BuildOpts) error {
+	// Detect trimpath and race from compiler args.
+	opts.Trimpath = hasExplicitTrimpath(args)
+	opts.Race = hasRaceFlag(args)
 	pkgName := getPkgNameFromArgs(args)
 
 	// Check if this package needs overlay
@@ -29,7 +30,7 @@ func handleCompile(ctx context.Context, toolPath string, args []string, embedCod
 		// Render overlay for this package only.
 		// Pass counter mode so testdeps overlay uses the correct coverage mode.
 		counterMode := "set"
-		if race {
+		if opts.Race {
 			counterMode = "atomic"
 		}
 		pkg, err := overlay.RenderPackage(def, sourceFiles, map[string]string{
@@ -52,11 +53,11 @@ func handleCompile(ctx context.Context, toolPath string, args []string, embedCod
 		// Pass toolexec and trimpath to ensure packages are compiled with the
 		// same build cache entries as the outer build, preventing fingerprint
 		// mismatches at link time.
-		toolexec, err := tobariToolexec(embedCode)
+		toolexec, err := tobariToolexec(opts)
 		if err != nil {
 			return err
 		}
-		if err := addMissingImportsToImportcfg(args, pkg.Imports, toolexec, trimpath, race); err != nil {
+		if err := addMissingImportsToImportcfg(args, pkg.Imports, toolexec, opts); err != nil {
 			return err
 		}
 	}
@@ -68,7 +69,7 @@ func handleCompile(ctx context.Context, toolPath string, args []string, embedCod
 	// tobari would fail with relocation errors at link time.
 	// When embed-code is enabled, also inject the source extraction hook.
 	if pkgName == "main" {
-		hookFile, err := generateMainHook(embedCode)
+		hookFile, err := generateMainHook(opts.EmbedCode)
 		if err != nil {
 			return fmt.Errorf("failed to generate main hook: %w", err)
 		}
@@ -81,7 +82,7 @@ func handleCompile(ctx context.Context, toolPath string, args []string, embedCod
 		// to find the correctly-built tobari packages without needing to
 		// detect individual flags.
 		if importCfgPath := getImportcfgPathFromArgs(args); importCfgPath != "" {
-			pkgs, err := getTobariPkgs(args, embedCode, trimpath, race)
+			pkgs, err := getTobariPkgs(args, opts)
 			if err != nil {
 				return fmt.Errorf("failed to build tobari packages: %w", err)
 			}
@@ -98,7 +99,7 @@ func handleCompile(ctx context.Context, toolPath string, args []string, embedCod
 	if err != nil {
 		return err
 	}
-	if err := addTobariPkgsToImportcfgFromCompileOptions(args, embedCode, trimpath, race); err != nil {
+	if err := addTobariPkgsToImportcfgFromCompileOptions(args, opts); err != nil {
 		return err
 	}
 	runCommand(toolPath, args)
@@ -151,7 +152,7 @@ func generateMainHook(embedCode bool) (string, error) {
 // there may be cases where it doesn't exist in the importcfg as is.
 // In such cases, if the target test uses github.com/goccy/tobari, linking is possible;
 // however, if it doesn't use it, a tobari package must be created dynamically and its path specified.
-func addTobariPkgsToImportcfgFromCompileOptions(args []string, embedCode bool, trimpath bool, race bool) error {
+func addTobariPkgsToImportcfgFromCompileOptions(args []string, opts BuildOpts) error {
 	importCfgPath := getImportcfgPathFromArgs(args)
 
 	var goFiles []string
@@ -197,7 +198,7 @@ SEARCH_TOBARI_PKG_END:
 		return nil
 	}
 
-	pkgs, err := getTobariPkgs(args, embedCode, trimpath, race)
+	pkgs, err := getTobariPkgs(args, opts)
 	if err != nil {
 		return err
 	}
@@ -220,7 +221,7 @@ func getPkgNameFromArgs(args []string) string {
 // for packages imported by the overlay's tobari.go file.
 // toolexec and trimpath are passed to GoListExportMap so that packages use
 // the same build cache entries as the outer build.
-func addMissingImportsToImportcfg(args []string, imports []string, toolexec string, trimpath bool, race bool) error {
+func addMissingImportsToImportcfg(args []string, imports []string, toolexec string, opts BuildOpts) error {
 	importCfgPath := getImportcfgPathFromArgs(args)
 	if importCfgPath == "" {
 		return nil
@@ -250,7 +251,12 @@ func addMissingImportsToImportcfg(args []string, imports []string, toolexec stri
 	}
 
 	// Get export paths for missing imports via go list
-	exportPaths, err := utils.GoListExportMap(missingImports, toolexec, trimpath, race)
+	exportPaths, err := utils.GoListExportMap(missingImports, utils.GoListOpts{
+		Toolexec:  toolexec,
+		Trimpath:  opts.Trimpath,
+		Race:      opts.Race,
+		BuildTags: opts.BuildTags,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get export paths: %w", err)
 	}

--- a/internal/tool/handler.go
+++ b/internal/tool/handler.go
@@ -15,19 +15,19 @@ import (
 	"github.com/goccy/tobari/internal/overlay"
 )
 
-func Handle(ctx context.Context, args []string, embedCode bool) error {
+func Handle(ctx context.Context, args []string, opts BuildOpts) error {
 	toolPath := args[1]
 	toolArgs := args[2:]
 
 	// Handle -V=full flag to isolate build cache
 	if slices.Contains(toolArgs, "-V=full") {
-		return handleVersionFull(ctx, toolPath, toolArgs, embedCode)
+		return handleVersionFull(ctx, toolPath, toolArgs, opts.EmbedCode)
 	}
 
 	toolName := filepath.Base(toolPath)
 	switch toolName {
 	case "compile":
-		if err := handleCompile(ctx, toolPath, toolArgs, embedCode); err != nil {
+		if err := handleCompile(ctx, toolPath, toolArgs, opts); err != nil {
 			return err
 		}
 	case "vet":
@@ -35,11 +35,11 @@ func Handle(ctx context.Context, args []string, embedCode bool) error {
 			return err
 		}
 	case "link":
-		if err := handleLink(ctx, toolPath, toolArgs, embedCode); err != nil {
+		if err := handleLink(ctx, toolPath, toolArgs, opts); err != nil {
 			return err
 		}
 	case "cover":
-		if err := handleCover(ctx, toolPath, toolArgs, embedCode); err != nil {
+		if err := handleCover(ctx, toolPath, toolArgs, opts.EmbedCode); err != nil {
 			return err
 		}
 	default:
@@ -85,6 +85,8 @@ func handleVersionFull(ctx context.Context, toolPath string, args []string, embe
 	// - embedCode: separates cache between embed and non-embed builds
 	// Note: trimpath cache separation is handled by Go itself, since -trimpath changes
 	// the compiler args which are already part of Go's cache key.
+	// Note: -tags cache separation is handled by Go itself, since tags change the set
+	// of source files which are already part of Go's cache key.
 	fmt.Printf("%s tobari:%s exe:%s embed:%v\n",
 		strings.TrimSpace(string(org)), overlayHash, exeHash, embedCode)
 	return nil

--- a/internal/tool/link.go
+++ b/internal/tool/link.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func handleLink(ctx context.Context, toolPath string, args []string, embedCode bool) error {
+func handleLink(ctx context.Context, toolPath string, args []string, opts BuildOpts) error {
 	importCfgPath := getImportcfgPathFromArgs(args)
 	if importCfgPath == "" {
 		runCommand(toolPath, args)
@@ -15,7 +15,7 @@ func handleLink(ctx context.Context, toolPath string, args []string, embedCode b
 	// Try to load cached tobari packages. The cache is written during the
 	// compile phase of the main package, keyed by the runtime package's
 	// export filename, which uniquely identifies the build configuration
-	// (including flags like -trimpath, -race, etc.).
+	// (including flags like -trimpath, -race, -tags, etc.).
 	if pkgs, ok := loadTobariPkgsCache(importCfgPath); ok {
 		if err := overwriteImportcfg(importCfgPath, pkgs); err != nil {
 			return fmt.Errorf("failed to update importcfg: %w", err)
@@ -24,7 +24,11 @@ func handleLink(ctx context.Context, toolPath string, args []string, embedCode b
 		// Cache miss: fall back to building tobari packages without flag
 		// information. This path is hit only if the compile phase was
 		// skipped entirely AND no prior cache exists.
-		pkgs, err := getTobariPkgs(args, embedCode, false, false)
+		fallbackOpts := BuildOpts{
+			EmbedCode: opts.EmbedCode,
+			BuildTags: opts.BuildTags,
+		}
+		pkgs, err := getTobariPkgs(args, fallbackOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/tool/opts.go
+++ b/internal/tool/opts.go
@@ -1,0 +1,10 @@
+package tool
+
+// BuildOpts bundles build configuration that is threaded through
+// compile, link, and inner build phases.
+type BuildOpts struct {
+	EmbedCode bool
+	Trimpath  bool
+	Race      bool
+	BuildTags string
+}

--- a/internal/utils/go.go
+++ b/internal/utils/go.go
@@ -95,26 +95,43 @@ func GoModTidy(dir string) error {
 	return nil
 }
 
+// GoListOpts bundles options for go list invocations.
+type GoListOpts struct {
+	Toolexec  string
+	Trimpath  bool
+	Race      bool
+	BuildTags string
+}
+
+// goListArgs returns the common flags derived from the options.
+func (o GoListOpts) goListArgs() []string {
+	var args []string
+	if o.Toolexec != "" {
+		args = append(args, "-toolexec="+o.Toolexec)
+	}
+	if o.Trimpath {
+		args = append(args, "-trimpath")
+	}
+	if o.Race {
+		args = append(args, "-race")
+	}
+	if o.BuildTags != "" {
+		args = append(args, "-tags="+o.BuildTags)
+	}
+	return args
+}
+
 // GoListExportMap runs `go list -export -json` for the given packages
 // and returns a map of import path -> export file path.
 // When toolexec and trimpath are provided, they are passed to `go list`
 // so that the compiled packages use the same build cache entries as the
 // outer build, ensuring matching fingerprints at link time.
-func GoListExportMap(pkgs []string, toolexec string, trimpath bool, race bool) (map[string]string, error) {
+func GoListExportMap(pkgs []string, opts GoListOpts) (map[string]string, error) {
 	bin, err := GoBin()
 	if err != nil {
 		return nil, err
 	}
-	args := []string{"list", "-export", "-json"}
-	if toolexec != "" {
-		args = append(args, "-toolexec="+toolexec)
-	}
-	if trimpath {
-		args = append(args, "-trimpath")
-	}
-	if race {
-		args = append(args, "-race")
-	}
+	args := append([]string{"list", "-export", "-json"}, opts.goListArgs()...)
 	args = append(args, pkgs...)
 	cmd := exec.Command(bin, args...)
 	// Strip GOFLAGS to prevent tobari's -toolexec from being inherited,
@@ -135,18 +152,12 @@ func GoListExportMap(pkgs []string, toolexec string, trimpath bool, race bool) (
 // the same -trimpath value and action ID as the outer build. This ensures that
 // the inner build produces standard library packages in the same build cache
 // entries as the outer build, preventing fingerprint mismatches at link time.
-func GoListDepsExport(dir string, toolexec string, trimpath bool, race bool, pkg string) (map[string]string, error) {
+func GoListDepsExport(dir string, opts GoListOpts, pkg string) (map[string]string, error) {
 	bin, err := GoBin()
 	if err != nil {
 		return nil, err
 	}
-	args := []string{"list", "-deps", "-export", "-json", "-toolexec=" + toolexec}
-	if trimpath {
-		args = append(args, "-trimpath")
-	}
-	if race {
-		args = append(args, "-race")
-	}
+	args := append([]string{"list", "-deps", "-export", "-json"}, opts.goListArgs()...)
 	args = append(args, pkg)
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = dir
@@ -176,7 +187,10 @@ func parseGoListExportJSON(data []byte) (map[string]string, error) {
 	return ret, nil
 }
 
-// envs stripped GOFLAGS to prevent -cover/-toolexec.
+// filterGOFLAGSEnvs strips GOFLAGS to prevent -cover/-toolexec from being
+// inherited by inner go list invocations, which would cause recursive
+// invocations and double coverage instrumentation. Build tags and other
+// flags are passed explicitly via function parameters instead.
 func filterGOFLAGSEnvs() []string {
 	envs := os.Environ()
 	newEnvs := make([]string, 0, len(envs))

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -458,6 +458,67 @@ func TestRace(t *testing.T) {
 	}
 }
 
+// TestTags verifies that tobari works correctly with `-tags`.
+//
+// Background:
+// When `go build -tags timetzdata` or `go test -tags timetzdata` is used,
+// the Go toolchain compiles standard library packages (e.g., time) with
+// different source files. Unlike -trimpath and -race, -tags is resolved by
+// the `go` command before invoking the compiler, so tobari cannot auto-detect
+// it from compiler arguments. Instead, the user specifies -tags via
+// `tobari flags -tags=VALUE`, which outputs both -tags (for go build) and
+// --build-tags (for tobari's toolexec) in GOFLAGS. tobari's inner builds
+// inherit -tags from the filtered GOFLAGS, preventing fingerprint mismatches.
+func TestTags(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari")
+
+	// Build tobari
+	if out, err := exec.CommandContext(ctx, "go", "build", "-o", tobariBin, "./cmd/tobari").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+
+	// Get tobari flags with -tags=timetzdata.
+	// This outputs: -cover -tags=timetzdata '-toolexec=tobari --build-tags=timetzdata'
+	flagsCmd := exec.CommandContext(ctx, tobariBin, "flags", "-tags=timetzdata")
+	flagsCmd.Dir = "testdata/notobari"
+	flagsOut, err := flagsCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("tobari flags failed: %s: %v", string(flagsOut), err)
+	}
+	tobariFlags := strings.TrimSpace(string(flagsOut))
+
+	env := os.Environ()
+	env = append(env, "GOFLAGS="+tobariFlags)
+
+	// Clean go build cache for a fresh start
+	if out, err := exec.CommandContext(ctx, "go", "clean", "-cache").CombinedOutput(); err != nil {
+		t.Fatalf("failed to clean cache: %s: %v", string(out), err)
+	}
+
+	// First run: go test with -tags timetzdata via tobari
+	cmd1 := exec.CommandContext(ctx, "go", "test", ".", "-count=1")
+	cmd1.Env = env
+	cmd1.Dir = "testdata/notobari"
+	if out, err := cmd1.CombinedOutput(); err != nil {
+		if strings.Contains(string(out), "fingerprint mismatch") {
+			t.Fatalf("fingerprint mismatch with -tags timetzdata: %s", string(out))
+		}
+		t.Fatalf("first go test -tags timetzdata failed: %s: %v", string(out), err)
+	}
+
+	// Second run: verify cache works with -tags
+	cmd2 := exec.CommandContext(ctx, "go", "test", ".", "-count=1")
+	cmd2.Env = env
+	cmd2.Dir = "testdata/notobari"
+	if out, err := cmd2.CombinedOutput(); err != nil {
+		if strings.Contains(string(out), "fingerprint mismatch") {
+			t.Fatalf("fingerprint mismatch on cached -tags timetzdata build: %s", string(out))
+		}
+		t.Fatalf("second go test -tags timetzdata failed: %s: %v", string(out), err)
+	}
+}
+
 func TestEmbedCode(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Add `-tags` option to `tobari flags` command so that `GOFLAGS=$(tobari flags -tags=timetzdata) go build ./...` passes build tags to both `go build` and tobari's inner builds, preventing fingerprint mismatches
- Introduce `--build-tags` as tobari's internal toolexec option (distinct from go's `-tags`) to thread tag information through compile/link phases
- Refactor build configuration parameters into `BuildOpts` (tool package) and `GoListOpts` (utils package) structs to reduce parameter proliferation

## Test plan
- [x] `TestTags` verifies clean build and cached build with `-tags=timetzdata` produce no fingerprint mismatch
- [x] All existing tests pass (`go test ./internal/...`)
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)