### PR TITLE
Fix AddCoverMeta init ordering panic by deferring JSON parse

### DIFF
--- a/internal/tobari/tobari.go
+++ b/internal/tobari/tobari.go
@@ -42,6 +42,7 @@ func ClearCounters() {
 }
 
 func CoverEntriesByName(name string) []*CoverEntry {
+	decodeRawMetas()
 	entryMapMu.RLock()
 	defer entryMapMu.RUnlock()
 
@@ -68,6 +69,7 @@ func CoverprofileMap(mode string) map[string]string {
 }
 
 func CoverEntriesMap() map[string][]*CoverEntry {
+	decodeRawMetas()
 	entryMapMu.RLock()
 	defer entryMapMu.RUnlock()
 
@@ -79,6 +81,7 @@ func CoverEntriesMap() map[string][]*CoverEntry {
 }
 
 func WriteCoverprofile(mode string, w io.Writer) {
+	decodeRawMetas()
 	entryMapMu.RLock()
 	defer entryMapMu.RUnlock()
 
@@ -92,6 +95,7 @@ func WriteCoverprofile(mode string, w io.Writer) {
 }
 
 func WriteCoverprofileByName(name, mode string, w io.Writer) {
+	decodeRawMetas()
 	entryMapMu.RLock()
 	defer entryMapMu.RUnlock()
 
@@ -105,6 +109,7 @@ func WriteCoverprofileByName(name, mode string, w io.Writer) {
 }
 
 func WriteAllCoverprofile(mode string, w io.Writer) {
+	decodeRawMetas()
 	gMapMu.RLock()
 	defer gMapMu.RUnlock()
 
@@ -323,6 +328,9 @@ var (
 	allCoverprofileMapMu   sync.RWMutex
 	chanGIDMap             map[uintptr]*chanLinks
 	chanGIDMapMu           sync.Mutex
+	rawMetas               []string
+	rawMetasMu             sync.Mutex
+	rawMetasOnce           sync.Once
 )
 
 type chanLinks struct {
@@ -537,47 +545,61 @@ func initMap() {
 
 func AddCoverMeta(s string) bool {
 	initMap()
-	var md Metadata
-	if err := json.Unmarshal([]byte(s), &md); err != nil {
-		panic(err)
-	}
-	allCoverprofileMapMu.Lock()
-
-	funcMapMu.Lock()
-	for _, fn := range md.Funcs {
-		funcMap[fn.Name] = fn
-		funcNames = append(funcNames, fn.Name)
-	}
-	funcMapMu.Unlock()
-
-	for _, fn := range md.Funcs {
-		for _, block := range fn.Blocks {
-			bid := blockID(md.FileName, block.Idx)
-			block.FileName = md.FileName
-			block.Function = fn
-
-			blockMapMu.Lock()
-			blockMap[bid] = block
-			blockMapMu.Unlock()
-
-			allCoverprofileMap[bid] = &CoverEntry{
-				FileName:  md.FileName,
-				StartLine: block.Start.Line,
-				StartCol:  block.Start.Col,
-				EndLine:   block.End.Line,
-				EndCol:    block.End.Col,
-				NumStmts:  block.NumStmts,
-			}
-			allCoverprofileMapKeys = append(allCoverprofileMapKeys, bid)
-		}
-	}
-	allCoverprofileMapMu.Unlock()
-
-	mdMu.Lock()
-	mds = append(mds, &md)
-	mdMu.Unlock()
-
+	rawMetasMu.Lock()
+	rawMetas = append(rawMetas, s)
+	rawMetasMu.Unlock()
 	return true
+}
+
+func decodeRawMetas() {
+	rawMetasOnce.Do(func() {
+		rawMetasMu.Lock()
+		snapshot := make([]string, len(rawMetas))
+		copy(snapshot, rawMetas)
+		rawMetasMu.Unlock()
+
+		for _, s := range snapshot {
+			var md Metadata
+			if err := json.Unmarshal([]byte(s), &md); err != nil {
+				panic(err)
+			}
+			allCoverprofileMapMu.Lock()
+
+			funcMapMu.Lock()
+			for _, fn := range md.Funcs {
+				funcMap[fn.Name] = fn
+				funcNames = append(funcNames, fn.Name)
+			}
+			funcMapMu.Unlock()
+
+			for _, fn := range md.Funcs {
+				for _, block := range fn.Blocks {
+					bid := blockID(md.FileName, block.Idx)
+					block.FileName = md.FileName
+					block.Function = fn
+
+					blockMapMu.Lock()
+					blockMap[bid] = block
+					blockMapMu.Unlock()
+
+					allCoverprofileMap[bid] = &CoverEntry{
+						FileName:  md.FileName,
+						StartLine: block.Start.Line,
+						StartCol:  block.Start.Col,
+						EndLine:   block.End.Line,
+						EndCol:    block.End.Col,
+						NumStmts:  block.NumStmts,
+					}
+					allCoverprofileMapKeys = append(allCoverprofileMapKeys, bid)
+				}
+			}
+			allCoverprofileMapMu.Unlock()
+
+			mdMu.Lock()
+			mds = append(mds, &md)
+			mdMu.Unlock()
+		}
+	})
 }
 
 func toEntries(coverMap map[string]*CoverEntry) []*CoverEntry {
@@ -626,6 +648,7 @@ type CoverReportCountData struct {
 // CollectCoverReportData builds compact coverage data from the current
 // internal state (allCoverprofileMap + CoverEntriesMap).
 func CollectCoverReportData() *CoverReportData {
+	decodeRawMetas()
 	allCoverprofileMapMu.RLock()
 	defer allCoverprofileMapMu.RUnlock()
 
@@ -842,6 +865,7 @@ func MarshalReportDataTOON(data *CoverReportData) ([]byte, error) {
 }
 
 func EncodeMeta() ([]byte, error) {
+	decodeRawMetas()
 	mdMu.RLock()
 	defer mdMu.RUnlock()
 
@@ -854,6 +878,7 @@ type CoverageFuncCounter struct {
 }
 
 func EncodeCounters() ([]byte, error) {
+	decodeRawMetas()
 	mdMu.RLock()
 	gMapMu.RLock()
 	defer mdMu.RUnlock()

--- a/testdata/initorder/go.mod
+++ b/testdata/initorder/go.mod
@@ -1,0 +1,3 @@
+module example.com/initorder
+
+go 1.23

--- a/testdata/initorder/main.go
+++ b/testdata/initorder/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"example.com/initorder/mathutil"
+)
+
+func main() {
+	fmt.Println(mathutil.Add(1, 2))
+	fmt.Println(mathutil.Multiply(3, 4))
+}

--- a/testdata/initorder/mathutil/mathutil.go
+++ b/testdata/initorder/mathutil/mathutil.go
@@ -1,0 +1,12 @@
+package mathutil
+
+func Add(a, b int) int {
+	return a + b
+}
+
+func Multiply(a, b int) int {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	return a * b
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -202,6 +202,12 @@ func TestCacheBehavior(t *testing.T) {
 			runDir:   "testdata/generic",
 			hasTest:  true,
 		},
+		{
+			name:     "initorder",
+			flagsDir: "testdata/initorder",
+			runDir:   "testdata/initorder",
+			runArgs:  []string{"main.go"},
+		},
 	}
 
 	goFlagsEnv := func(tobariFlags []string) []string {


### PR DESCRIPTION
## Summary
- `AddCoverMeta` is called via `//go:linkname` during package init, but since linkname bypasses Go's import dependency graph, `encoding/json` may not be initialized yet — causing `panic: reflect: nil type passed to Type.Implements`
- Fix by deferring `json.Unmarshal` to first access via `decodeRawMetas()` (guarded by `sync.Once`), so `AddCoverMeta` only stores the raw JSON string at init time
- Add `testdata/initorder/` test case with a sub-package that doesn't import `encoding/json`, reproducing the init ordering issue

## Test plan
- [x] `go test -run TestCacheBehavior/clean_cache/initorder -v -count=1` passes
- [x] `go test ./... -count=1` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)