### PR TITLE
Replace binary hash with version + options hash in build cache key

### DIFF
--- a/internal/tool/handler.go
+++ b/internal/tool/handler.go
@@ -2,10 +2,7 @@ package tool
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/goccy/tobari/internal/overlay"
+	"github.com/goccy/tobari/internal/version"
 )
 
 func Handle(ctx context.Context, args []string, opts BuildOpts) error {
@@ -21,7 +19,7 @@ func Handle(ctx context.Context, args []string, opts BuildOpts) error {
 
 	// Handle -V=full flag to isolate build cache
 	if slices.Contains(toolArgs, "-V=full") {
-		return handleVersionFull(ctx, toolPath, toolArgs, opts.EmbedCode)
+		return handleVersionFull(ctx, toolPath, toolArgs, opts)
 	}
 
 	toolName := filepath.Base(toolPath)
@@ -63,7 +61,7 @@ func runCommand(bin string, args []string) {
 	}
 }
 
-func handleVersionFull(ctx context.Context, toolPath string, args []string, embedCode bool) error {
+func handleVersionFull(ctx context.Context, toolPath string, args []string, opts BuildOpts) error {
 	org, err := exec.CommandContext(ctx, toolPath, args...).Output()
 	if err != nil {
 		return fmt.Errorf("failed to run -V=full: %w", err)
@@ -74,40 +72,18 @@ func handleVersionFull(ctx context.Context, toolPath string, args []string, embe
 		return fmt.Errorf("failed to compute overlay hash: %w", err)
 	}
 
-	exeHash, err := executableHash()
+	ver, err := version.Get()
 	if err != nil {
-		return fmt.Errorf("failed to compute executable hash: %w", err)
+		return fmt.Errorf("failed to get tobari version: %w", err)
 	}
 
-	// Output version with tobari hashes; Go uses this as part of the build cache key.
-	// - overlayHash: invalidates cache when overlay files change (e.g., Go version update)
-	// - exeHash: invalidates cache when the tobari binary changes (e.g., new tobari release)
-	// - embedCode: separates cache between embed and non-embed builds
-	// Note: trimpath cache separation is handled by Go itself, since -trimpath changes
-	// the compiler args which are already part of Go's cache key.
-	// Note: -tags cache separation is handled by Go itself, since tags change the set
-	// of source files which are already part of Go's cache key.
-	fmt.Printf("%s tobari:%s exe:%s embed:%v\n",
-		strings.TrimSpace(string(org)), overlayHash, exeHash, embedCode)
+	// Output version with tobari identifiers; Go uses this as part of the build cache key.
+	// - version: invalidates cache when tobari version changes (e.g., new release)
+	// - overlay: invalidates cache when overlay files change (e.g., Go version update)
+	// - opt: invalidates cache when toolexec options change (e.g., --embed-code)
+	// Note: trimpath and race are excluded from opt because they are detected later
+	// from compiler args and Go already includes them in its own cache key.
+	fmt.Printf("%s tobari:[version:%s overlay:%s opt:%s]\n",
+		strings.TrimSpace(string(org)), ver.ID(), overlayHash, opts.Hash())
 	return nil
-}
-
-func executableHash() (string, error) {
-	exe, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-	f, err := os.Open(exe)
-	if err != nil {
-		return "", err
-	}
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		_ = f.Close()
-		return "", err
-	}
-	if err := f.Close(); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/tool/opts.go
+++ b/internal/tool/opts.go
@@ -1,5 +1,11 @@
 package tool
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
 // BuildOpts bundles build configuration that is threaded through
 // compile, link, and inner build phases.
 type BuildOpts struct {
@@ -7,4 +13,14 @@ type BuildOpts struct {
 	Trimpath  bool
 	Race      bool
 	BuildTags string
+}
+
+// Hash returns a short hash derived from the toolexec options that affect
+// code generation (EmbedCode, BuildTags). Trimpath and Race are excluded
+// because they are detected later from compiler args and Go already
+// includes them in its own cache key.
+func (o BuildOpts) Hash() string {
+	s := fmt.Sprintf("build-tags=%s,embed-code=%v", o.BuildTags, o.EmbedCode)
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])[:16]
 }


### PR DESCRIPTION
## Summary
- Replace the SHA-256 hash of the entire tobari binary (`exe:<hash>`) with the tobari version string (`version.Get().ID()`) and a hash of toolexec options (`EmbedCode`, `BuildTags`) in the `-V=full` build cache key
- This prevents build cache invalidation when reinstalling the same version of tobari (which previously changed the binary hash due to VCS info or build path differences)
- Remove the now-unused `executableHash` function and add a `Hash()` method to `BuildOpts`

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [ ] `go build -toolexec='tobari' -x ./...` outputs new format `tobari:[version:... overlay:... opt:...]`
- [ ] Rebuild with same options confirms cache hit
- [ ] `--embed-code` flag changes the `opt:` value
- [ ] `--build-tags=foo` flag changes the `opt:` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)