### PR TITLE
Fix funcMap lookup panic in resolveCandidateFuncMap

### DIFF
--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -156,6 +156,10 @@ func createLightweightFuncInfo(pkgcfg *PackageConfig, inputFiles []string) (*Fun
 	pendingRanges := make(map[funcPos]struct{})
 
 	globalAnonIdx := 1
+	// SSA always creates a synthetic init function (named "init") for
+	// package-level variable initialization. Explicit init() functions
+	// declared by the programmer are numbered init#1, init#2, etc.
+	initCount := 1
 	for _, file := range files {
 		var curAnon *anonState
 
@@ -166,6 +170,10 @@ func createLightweightFuncInfo(pkgcfg *PackageConfig, inputFiles []string) (*Fun
 					return false
 				}
 				fqdn := buildFuncNameFromAST(pkgcfg.PkgPath, decl)
+				if decl.Name.Name == "init" && decl.Recv == nil {
+					fqdn = fmt.Sprintf("%s.init#%d", pkgcfg.PkgPath, initCount)
+					initCount++
+				}
 				pos := fset.Position(decl.Name.Pos())
 				funcNames[funcPos{
 					Filename: filepath.Clean(pos.Filename),

--- a/internal/tobari/tobari.go
+++ b/internal/tobari/tobari.go
@@ -241,7 +241,12 @@ func resolveCandidateFuncMap(fn *Function, fnMap map[*Function]struct{}) {
 	for _, dep := range fn.Deps {
 		ref, exists := funcMap[dep]
 		if !exists {
-			panic(fmt.Sprintf("tobari: failed to find function reference by %s from %v\n", dep, funcNames))
+			// funcMap is the ground truth for packages instrumented in this
+			// binary (populated via AddCoverMeta at init time). suppDeps may
+			// reference functions from packages that are in the global cover
+			// cache but not instrumented in this binary. Use funcMap as the
+			// runtime coverPkgSet and skip deps outside of it.
+			continue
 		}
 		fn.DepRefs = append(fn.DepRefs, ref)
 	}

--- a/testdata/crossdeps/go.mod
+++ b/testdata/crossdeps/go.mod
@@ -1,0 +1,3 @@
+module example.com/crossdeps
+
+go 1.23

--- a/testdata/crossdeps/pkga/pkga.go
+++ b/testdata/crossdeps/pkga/pkga.go
@@ -1,0 +1,11 @@
+package pkga
+
+import "example.com/crossdeps/pkgb"
+
+func QuadGreet(name string) string {
+	return pkgb.Greet(name) + "!" + pkgb.Greet(name) + "!"
+}
+
+func Quadruple(x int) int {
+	return pkgb.Double(pkgb.Double(x))
+}

--- a/testdata/crossdeps/pkga/pkga_test.go
+++ b/testdata/crossdeps/pkga/pkga_test.go
@@ -1,0 +1,13 @@
+package pkga_test
+
+import (
+	"testing"
+
+	"example.com/crossdeps/pkga"
+)
+
+func TestQuadruple(t *testing.T) {
+	if got := pkga.Quadruple(3); got != 12 {
+		t.Errorf("Quadruple(3) = %d, want 12", got)
+	}
+}

--- a/testdata/crossdeps/pkgb/pkgb.go
+++ b/testdata/crossdeps/pkgb/pkgb.go
@@ -1,0 +1,9 @@
+package pkgb
+
+func Double(x int) int {
+	return x * 2
+}
+
+func Greet(name string) string {
+	return "hello, " + name
+}

--- a/testdata/crossdeps/pkgb/pkgb_test.go
+++ b/testdata/crossdeps/pkgb/pkgb_test.go
@@ -1,0 +1,13 @@
+package pkgb_test
+
+import (
+	"testing"
+
+	"example.com/crossdeps/pkgb"
+)
+
+func TestDouble(t *testing.T) {
+	if got := pkgb.Double(3); got != 6 {
+		t.Errorf("Double(3) = %d, want 6", got)
+	}
+}

--- a/testdata/initfunc/go.mod
+++ b/testdata/initfunc/go.mod
@@ -1,0 +1,3 @@
+module example.com/initfunc
+
+go 1.23

--- a/testdata/initfunc/initlib/initlib.go
+++ b/testdata/initfunc/initlib/initlib.go
@@ -1,0 +1,34 @@
+package initlib
+
+// Package-level variable closures (belong to SSA's synthetic init).
+var (
+	transform = func(s string) string { return "[" + s + "]" }
+	format    = func(s string) string { return "(" + s + ")" }
+)
+
+// First explicit init → SSA names it init#1.
+// Closures inside it → init#1$1, init#1$2.
+func init() {
+	fn1 := func(x int) int { return x + 1 }
+	fn2 := func(x int) int { return x * 2 }
+	_ = fn1(0)
+	_ = fn2(0)
+}
+
+// Second explicit init → SSA names it init#2.
+// Closure inside it → init#2$1, with nested closure → init#2$1$1.
+func init() {
+	outer := func(x int) int {
+		inner := func(y int) int { return y + x }
+		return inner(x)
+	}
+	_ = outer(0)
+}
+
+func Transform(s string) string {
+	return transform(s)
+}
+
+func Format(s string) string {
+	return format(s)
+}

--- a/testdata/initfunc/initlib/initlib_test.go
+++ b/testdata/initfunc/initlib/initlib_test.go
@@ -11,3 +11,9 @@ func TestTransform(t *testing.T) {
 		t.Errorf("Transform(x) = %q, want [x]", got)
 	}
 }
+
+func TestSuffix(t *testing.T) {
+	if got := initlib.Suffix(); got != "ready!" {
+		t.Errorf("Suffix() = %q, want %q", got, "ready!")
+	}
+}

--- a/testdata/initfunc/initlib/initlib_test.go
+++ b/testdata/initfunc/initlib/initlib_test.go
@@ -1,0 +1,13 @@
+package initlib_test
+
+import (
+	"testing"
+
+	"example.com/initfunc/initlib"
+)
+
+func TestTransform(t *testing.T) {
+	if got := initlib.Transform("x"); got != "[x]" {
+		t.Errorf("Transform(x) = %q, want [x]", got)
+	}
+}

--- a/testdata/initfunc/initlib/setup.go
+++ b/testdata/initfunc/initlib/setup.go
@@ -1,0 +1,14 @@
+package initlib
+
+// Third explicit init in a separate file → SSA names it init#3.
+// Closure inside it → init#3$1.
+func init() {
+	fn := func(s string) string { return s + "!" }
+	suffix = fn("ready")
+}
+
+var suffix string
+
+func Suffix() string {
+	return suffix
+}

--- a/testdata/initfunc/main.go
+++ b/testdata/initfunc/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"example.com/initfunc/initlib"
+)
+
+func main() {
+	fmt.Println(initlib.Transform("hello"))
+	fmt.Println(initlib.Format("world"))
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -456,6 +456,58 @@ func TestFingerprintConsistency(t *testing.T) {
 	}
 }
 
+// TestCrossPackageDeps verifies that go test -cover ./... (without -coverpkg)
+// does not panic when suppDeps references functions from dependency packages
+// that are not instrumented in the current test binary.
+//
+// Background:
+// CreateMainDeps uses the global cover cache to build coverPkgSet, which
+// may include dependency packages instrumented in other builds. The RTA
+// analysis then generates suppDeps referencing those packages' functions.
+// At runtime, funcMap only contains packages actually instrumented in this
+// binary (via AddCoverMeta). resolveCandidateFuncMap must skip deps not
+// in funcMap rather than panicking.
+//
+// Setup:
+// testdata/crossdeps has pkga (depends on pkgb) and pkgb, both with tests.
+// go test ./... tests both packages. When pkga's test runs, only pkga is
+// instrumented, but pkgb may be in the global cover cache (from pkgb's test).
+// suppDeps for pkga will reference pkgb.Double/pkgb.Greet, which are not
+// in pkga's funcMap → must be skipped without panic.
+func TestCrossPackageDeps(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari")
+
+	if out, err := exec.CommandContext(ctx, "go", "build", "-o", tobariBin, "./cmd/tobari").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+
+	flagsCmd := exec.CommandContext(ctx, tobariBin, "flags")
+	flagsCmd.Dir = "testdata/crossdeps"
+	flagsOut, err := flagsCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("tobari flags failed: %s: %v", string(flagsOut), err)
+	}
+	tobariFlags := strings.Split(strings.TrimSpace(string(flagsOut)), " ")
+	env := append(os.Environ(), "GOFLAGS="+strings.Join(tobariFlags, " "))
+
+	if out, err := exec.CommandContext(ctx, "go", "clean", "-cache").CombinedOutput(); err != nil {
+		t.Fatalf("failed to clean cache: %s: %v", string(out), err)
+	}
+
+	// Run go test ./... which tests both pkga and pkgb. Each test binary
+	// only instruments its own package (-cover without -coverpkg), but the
+	// global cover cache accumulates entries from all packages. pkga depends
+	// on pkgb, so pkga's suppDeps will reference pkgb functions that are not
+	// in pkga's funcMap.
+	cmd := exec.CommandContext(ctx, "go", "test", "./...", "-count=1")
+	cmd.Env = env
+	cmd.Dir = "testdata/crossdeps"
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go test ./... failed: %s: %v", string(out), err)
+	}
+}
+
 // TestTrimpath verifies that tobari works correctly with `-trimpath`.
 //
 // Background:

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -245,6 +245,13 @@ func TestCacheBehavior(t *testing.T) {
 			runDir:   "testdata/initorder",
 			runArgs:  []string{"main.go"},
 		},
+		{
+			name:     "initfunc",
+			flagsDir: "testdata/initfunc",
+			runDir:   "testdata/initfunc",
+			runArgs:  []string{"main.go"},
+			hasTest:  true,
+		},
 	}
 
 	goFlagsEnv := func(tobariFlags []string) []string {


### PR DESCRIPTION
## Summary

- Fix init function naming mismatch between AST-based naming and SSA convention. SSA names explicit `init()` functions as `init#1`, `init#2`, etc. (reserving `init` for the synthetic package-level variable initializer), but `createLightweightFuncInfo` named all explicit `init()` as `init`, causing closure name collisions (e.g., `init$1` vs `init#1$1`).
- Fix panic in `resolveCandidateFuncMap` when `suppDeps` references functions from packages not instrumented in the current binary. After the GOPACKAGESDRIVER change (#40), `CreateMainDeps` runs at testmain time and uses the global cover cache to build `coverPkgSet`, which may include packages from other builds. Use `funcMap` (populated via `AddCoverMeta` at init time) as the runtime `coverPkgSet` — since uninstrumented packages have no block counters or metadata, skipping their deps has no effect on coverage output.

## Test plan

- [x] Added `testdata/initfunc` with package-level variable closures, multiple explicit `init()` functions, and nested closures to cover init naming edge cases
- [x] `TestCacheBehavior/initfunc` passes for both `go_run` and `go_test` in clean and cached builds
- [x] `GOFLAGS=$(tobari flags) go test ./...` on [go-yaml](https://github.com/goccy/go-yaml) passes all packages without panic
- [x] All existing tobari tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)