### PR TITLE
Add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   lint:
     name: lint

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -10,7 +10,8 @@ on:
     paths:
       - .goreleaser.yml
       - .github/workflows/release-test.yml
-
+permissions:
+  contents: read
 jobs:
   release-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `.github/workflows/go.yml` and `.github/workflows/release-test.yml`
- Resolves all 4 CodeQL code-scanning alerts (`actions/missing-workflow-permissions` / CWE-275) by restricting GITHUB_TOKEN to the minimum required scope

## Test plan
- [ ] Verify CI workflows (lint, test, ko build, release-test) pass with the restricted permissions
- [ ] Confirm code-scanning alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)