### PR TITLE
Build release binaries with the latest stable Go toolchain

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ./go.mod
+          go-version: 'stable'
 
       - name: Run GoReleaser (dry-run)
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ./go.mod
+          go-version: 'stable'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
## Summary
- Switch the release and release-test workflows to use the latest stable Go (`go-version: stable`) so tobari is always built with the newest Go toolchain (currently 1.26.x).
- Previously both workflows used `go-version-file: ./go.mod`, which pinned the release build to Go 1.24.0.

## Why
tobari is a `toolexec` wrapper that hooks into the Go toolchain of the user's target application. If the released tobari binary itself is built with an older Go version, it can lack support for language and runtime features introduced in newer Go releases (e.g. new generics features, new SSA constructs, runtime/testing internals). The go.mod version represents the *minimum* Go required to build tobari from source — it should not gate which toolchain the released binary is built with.

## Test plan
- [ ] `release-test` workflow runs successfully on this PR (dry-run goreleaser with the stable Go toolchain).
- [ ] After merge, cut a tag and confirm the `release` workflow uses the latest stable Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
