### PR TITLE
Preserve //go:linkname directives when overlaying stdlib packages

### DIFF
--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"text/template"
 
 	"github.com/goccy/tobari/internal/utils"
@@ -120,7 +121,7 @@ func ComputeHash() (string, error) {
 			}
 
 			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, pkgFile, src, 0)
+			file, err := parser.ParseFile(fset, pkgFile, src, parser.ParseComments)
 			if err != nil {
 				return "", fmt.Errorf("failed to parse package file %s: %w", pkgFile, err)
 			}
@@ -136,6 +137,7 @@ func ComputeHash() (string, error) {
 					continue
 				}
 				newName := fn.Name + "_" + funcSuffix
+				stripLinknameDirectives(funcDecl.Doc, fn.Name)
 				funcDecl.Name = &ast.Ident{Name: newName}
 				pkgScopedReplacedNameMap[fn.Name] = newName
 				hasRename = true
@@ -202,7 +204,7 @@ func RenderPackage(def *Definition, sourceFiles []string, templateVars map[strin
 		}
 
 		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, srcFile, src, 0)
+		file, err := parser.ParseFile(fset, srcFile, src, parser.ParseComments)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse source file %s: %w", srcFile, err)
 		}
@@ -218,6 +220,7 @@ func RenderPackage(def *Definition, sourceFiles []string, templateVars map[strin
 				continue
 			}
 			newName := fn.Name + "_" + funcSuffix
+			stripLinknameDirectives(funcDecl.Doc, fn.Name)
 			funcDecl.Name = &ast.Ident{Name: newName}
 			pkgScopedReplacedNameMap[fn.Name] = newName
 			hasRename = true
@@ -333,6 +336,31 @@ func atomicWriteFile(path string, content []byte) error {
 
 	// Atomic rename
 	return os.Rename(tmpPath, path)
+}
+
+// stripLinknameDirectives removes any //go:linkname directives from a
+// function's doc comment that name the given local symbol. Required when
+// renaming a function via overlay: the original directive is parsed by the
+// compiler regardless of the function's new name (the directive carries the
+// linkname literally), so leaving it in place would either keep the original
+// linkname bound to the renamed body, or — when tobari.go injects a new
+// function with the same linkname — produce a "duplicate //go:linkname"
+// compile error. Other directives (//go:nosplit, //go:noinline, etc.) are
+// preserved because they still apply to the renamed function.
+func stripLinknameDirectives(doc *ast.CommentGroup, localName string) {
+	if doc == nil {
+		return
+	}
+	exact := "//go:linkname " + localName
+	prefix := exact + " "
+	filtered := doc.List[:0]
+	for _, c := range doc.List {
+		if c.Text == exact || strings.HasPrefix(c.Text, prefix) {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	doc.List = filtered
 }
 
 func matchedFunc(def *Definition, decl *ast.FuncDecl) *Function {

--- a/testdata/synctest/go.mod
+++ b/testdata/synctest/go.mod
@@ -1,0 +1,3 @@
+module example.com/synctest
+
+go 1.25

--- a/testdata/synctest/main.go
+++ b/testdata/synctest/main.go
@@ -1,0 +1,5 @@
+package main
+
+func Add(a, b int) int { return a + b }
+
+func main() {}

--- a/testdata/synctest/main_test.go
+++ b/testdata/synctest/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+func TestAddInBubble(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		if Add(2, 3) != 5 {
+			t.Fatalf("Add(2,3) != 5")
+		}
+	})
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -202,6 +202,12 @@ func TestCacheBehavior(t *testing.T) {
 			expectedJSON: "expected_tobari.json",
 		},
 		{
+			name:     "synctest",
+			flagsDir: "testdata/synctest",
+			runDir:   "testdata/synctest",
+			hasTest:  true,
+		},
+		{
 			name:     "generic",
 			flagsDir: "testdata/generic",
 			runDir:   "testdata/generic",


### PR DESCRIPTION
## Summary

- The overlay parser was called with mode `0`, so `format.Node` dropped every comment when re-emitting the rewritten file. For the `testing` overlay (which renames `T.Run` inside `src/testing/testing.go`), this also stripped the `//go:linkname testingSynctestTest testing/synctest.testingSynctestTest` push directive on line 2124. Any test binary whose dependency closure pulled in `testing/synctest` then failed at link time with `testing/synctest.Test.func1: relocation target testing/synctest.testingSynctestTest not defined` (originally reported when running `go test ./...` against `kubernetes/pkg/scheduler/...`, which transitively uses `testing/synctest` via `test/utils/ktesting/tcontext.go`).
- Switch both `ComputeHash` and `RenderPackage` in `internal/overlay/overlay.go` to `parser.ParseComments` so `//go:` directives survive the AST round-trip.
- Add a `stripLinknameDirectives` helper that removes the original `//go:linkname` from a renamed function's doc comment. Without this, the wrapper injected by `tobari.go` (e.g. `runtime.coverage_getCovCounterList`) collides with the stale directive left on the renamed body, producing a `duplicate //go:linkname` compile error. Other directives (`//go:nosplit`, `//go:noinline`, etc.) are preserved because they still apply to the renamed function.
- Add `testdata/synctest/` as a minimal reproduction (a single test calling `synctest.Test`) and wire it into `TestCacheBehavior` so the regression is caught locally.

## Test plan

- [x] `go test ./internal/overlay/...` - overlay unit tests pass.
- [x] `go test -run TestCacheBehavior .` - full e2e suite passes including the new `synctest` case.
- [x] `cd testdata/synctest && go test -count=1 -cover -toolexec=.../tobari .` reproduces the linker failure on `main` and passes after the fix (coverage 100%).
- [x] `kubernetes/pkg/scheduler/backend/queue/...` with tobari (Go 1.26.2) - passes (coverage 91.7%); the original `testingSynctestTest` linker error is gone.
- [x] `kubernetes/pkg/kubelet/container/...` with tobari (uses `synctest.Test`/`synctest.Wait`) - passes (coverage 83.7%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
