### PR TITLE
Treat missing RTA entry points as no-op instead of error

### DIFF
--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -453,8 +453,11 @@ func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *Packa
 			}
 		}
 	}
+	// No entry points (main/init/Test*) means RTA has nothing to trace from,
+	// so no supplementary deps can be produced. Treat this as a no-op rather
+	// than a hard error — the build should still succeed.
 	if len(roots) == 0 {
-		return nil, fmt.Errorf("no entry points found in main package")
+		return nil, nil
 	}
 
 	rtaResult := rta.Analyze(roots, true)


### PR DESCRIPTION
## Summary
- `CreateMainDeps` returned `fmt.Errorf("no entry points found in main package")` when RTA had no main/init/Test* roots to seed from, which surfaced as a hard build failure during the cover tool phase.
- This is semantically the same situation as the other early-return paths in the same function (empty `coverPkgSet`, failed testmain directory resolution), which already return `(nil, nil)` and let the caller skip writing supplementary deps.
- Align the behavior by returning `(nil, nil)` here too, so the build still succeeds when RTA simply has nothing to trace.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cover/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)