### PR TITLE
Support Go-style "./..." patterns in tobari merge json

### DIFF
--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -39,11 +39,18 @@ Convert Command Options:
     -o <file>           Output coverprofile file path (default: cover.out)
 
 Merge Command:
-    tobari merge json [-o merged.json] <file1.json> <file2.json> [...]
+    tobari merge json [-o merged.json] <file.json|./...> [...]
     tobari merge source [-o merged.tar.gz] <a.tar.gz> <b.tar.gz> [...]
 
-    merge json      Merge multiple tobari.json files into one
-    merge source    Merge multiple source tar.gz archives into one
+    merge json      Merge multiple tobari.json files into one.
+                    Inputs may be literal file paths and/or Go-style "./..."
+                    package patterns. Pattern arguments walk the filesystem
+                    recursively and pick up every "tobari/tobari.json" file
+                    they find, skipping vendor/ and dot/underscore-prefixed
+                    directories. Symbolic links are not followed.
+                    Note: avoid pointing -o to a path ending in
+                    tobari/tobari.json, since the next run would pick it up.
+    merge source    Merge multiple source tar.gz archives into one.
                     Duplicate archives (same SHA-256 hash) are skipped.
                     Conflicting files (same path, different content) cause an error.
 
@@ -83,6 +90,9 @@ Examples:
 
     # Merge multiple tobari.json files
     tobari merge json -o merged.json a.json b.json
+
+    # Merge every tobari/tobari.json under the current directory recursively
+    tobari merge json -o merged.json ./...
 
     # Merge multiple source archives
     tobari merge source -o merged.tar.gz a.tar.gz b.tar.gz

--- a/internal/cli/merge_cmd.go
+++ b/internal/cli/merge_cmd.go
@@ -7,7 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/goccy/tobari"
@@ -28,25 +30,30 @@ func (c *CLI) runMergeCmd(ctx context.Context, args []string) error {
 }
 
 func (c *CLI) runMergeJSONCmd(_ context.Context, args []string) error {
-	fs := flag.NewFlagSet("merge json", flag.ContinueOnError)
-	fs.SetOutput(c.stderr)
-	output := fs.String("o", "merged.json", "output merged tobari.json file path")
+	flagSet := flag.NewFlagSet("merge json", flag.ContinueOnError)
+	flagSet.SetOutput(c.stderr)
+	output := flagSet.String("o", "merged.json", "output merged tobari.json file path")
 
-	if err := fs.Parse(args); err != nil {
+	if err := flagSet.Parse(args); err != nil {
 		return err
 	}
 
-	if fs.NArg() < 2 {
-		return fmt.Errorf("at least two input files required\nUsage: tobari merge json [-o merged.json] <file1.json> <file2.json> [...]")
+	if flagSet.NArg() == 0 {
+		return fmt.Errorf("missing input\nUsage: tobari merge json [-o merged.json] <file.json|./...> [...]")
 	}
-	for _, arg := range fs.Args() {
+	for _, arg := range flagSet.Args() {
 		if strings.HasPrefix(arg, "-") {
-			return fmt.Errorf("flags must be specified before input files\nUsage: tobari merge json [-o merged.json] <file1.json> <file2.json> [...]")
+			return fmt.Errorf("flags must be specified before input files\nUsage: tobari merge json [-o merged.json] <file.json|./...> [...]")
 		}
 	}
 
-	reports := make([]*tobari.CoverReport, 0, fs.NArg())
-	for _, inputFile := range fs.Args() {
+	inputFiles, err := expandMergeInputs(flagSet.Args())
+	if err != nil {
+		return err
+	}
+
+	reports := make([]*tobari.CoverReport, 0, len(inputFiles))
+	for _, inputFile := range inputFiles {
 		data, err := os.ReadFile(inputFile)
 		if err != nil {
 			return fmt.Errorf("failed to read input file %s: %w", inputFile, err)
@@ -79,18 +86,18 @@ func (c *CLI) runMergeJSONCmd(_ context.Context, args []string) error {
 }
 
 func (c *CLI) runMergeSourceCmd(_ context.Context, args []string) (e error) {
-	fs := flag.NewFlagSet("merge source", flag.ContinueOnError)
-	fs.SetOutput(c.stderr)
-	output := fs.String("o", "merged.tar.gz", "output merged source archive path")
+	flagSet := flag.NewFlagSet("merge source", flag.ContinueOnError)
+	flagSet.SetOutput(c.stderr)
+	output := flagSet.String("o", "merged.tar.gz", "output merged source archive path")
 
-	if err := fs.Parse(args); err != nil {
+	if err := flagSet.Parse(args); err != nil {
 		return err
 	}
 
-	if fs.NArg() < 2 {
+	if flagSet.NArg() < 2 {
 		return fmt.Errorf("at least two input files required\nUsage: tobari merge source [-o merged.tar.gz] <a.tar.gz> <b.tar.gz> [...]")
 	}
-	for _, arg := range fs.Args() {
+	for _, arg := range flagSet.Args() {
 		if strings.HasPrefix(arg, "-") {
 			return fmt.Errorf("flags must be specified before input files\nUsage: tobari merge source [-o merged.tar.gz] <a.tar.gz> <b.tar.gz> [...]")
 		}
@@ -103,8 +110,8 @@ func (c *CLI) runMergeSourceCmd(_ context.Context, args []string) (e error) {
 		}
 	}()
 
-	inputs := make([]io.Reader, 0, fs.NArg())
-	for _, inputFile := range fs.Args() {
+	inputs := make([]io.Reader, 0, flagSet.NArg())
+	for _, inputFile := range flagSet.Args() {
 		f, err := os.Open(inputFile)
 		if err != nil {
 			return fmt.Errorf("failed to open input file %s: %w", inputFile, err)
@@ -123,8 +130,131 @@ func (c *CLI) runMergeSourceCmd(_ context.Context, args []string) (e error) {
 		return fmt.Errorf("failed to merge source archives: %w", err)
 	}
 
-	if _, err := fmt.Fprintf(c.stdout, "Merged %d source archives into %s\n", fs.NArg(), *output); err != nil {
+	if _, err := fmt.Fprintf(c.stdout, "Merged %d source archives into %s\n", flagSet.NArg(), *output); err != nil {
 		return err
 	}
 	return nil
+}
+
+// classifyMergeArg classifies a single CLI argument for `tobari merge json`.
+// kind is "file" or "pattern". For "pattern" kind, base is the walk root.
+func classifyMergeArg(arg string) (kind string, base string, err error) {
+	if strings.HasPrefix(arg, "-") {
+		return "", "", fmt.Errorf("unexpected flag-like argument: %s", arg)
+	}
+	if arg == "..." {
+		return "", "", fmt.Errorf("bare '...' is not allowed; use './...' to walk from current directory")
+	}
+	slashed := filepath.ToSlash(arg)
+	if strings.HasSuffix(slashed, "/...") {
+		trimmed := strings.TrimSuffix(slashed, "/...")
+		if trimmed == "" {
+			return "", "", fmt.Errorf("pattern base must not be filesystem root: %s", arg)
+		}
+		return "pattern", filepath.Clean(filepath.FromSlash(trimmed)), nil
+	}
+	return "file", "", nil
+}
+
+// isTobariJSONPath reports whether p ends with the canonical
+// "tobari/tobari.json" path tobari writes per package.
+func isTobariJSONPath(p string) bool {
+	sp := filepath.ToSlash(p)
+	return sp == "tobari/tobari.json" || strings.HasSuffix(sp, "/tobari/tobari.json")
+}
+
+// shouldSkipMergeWalkDir reports whether a directory found during pattern
+// expansion should be skipped. The walk root itself is never skipped (the
+// caller passes path != root).
+func shouldSkipMergeWalkDir(name string) bool {
+	if name == "vendor" {
+		return true
+	}
+	if len(name) > 0 && (name[0] == '.' || name[0] == '_') {
+		return true
+	}
+	return false
+}
+
+// walkTobariJSON walks root recursively and returns paths to all
+// "tobari/tobari.json" files found, skipping vendor/ and dot/underscore-prefixed
+// directories. Symbolic links are not followed.
+func walkTobariJSON(root string) ([]string, error) {
+	var found []string
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if path == root {
+				return err
+			}
+			// Ignore permission errors etc. on subentries.
+			return nil
+		}
+		if d.IsDir() {
+			if path != root && shouldSkipMergeWalkDir(d.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if isTobariJSONPath(path) {
+			found = append(found, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return found, nil
+}
+
+// expandMergeInputs converts a raw argument list (mix of literal file paths
+// and "./..."-style patterns) into a deduplicated list of input file paths,
+// preserving discovery order.
+func expandMergeInputs(args []string) ([]string, error) {
+	seen := make(map[string]struct{})
+	var out []string
+	hasPattern := false
+	var patterns []string
+
+	add := func(p string) error {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return fmt.Errorf("failed to resolve absolute path for %s: %w", p, err)
+		}
+		if _, dup := seen[abs]; dup {
+			return nil
+		}
+		seen[abs] = struct{}{}
+		out = append(out, p)
+		return nil
+	}
+
+	for _, a := range args {
+		kind, base, err := classifyMergeArg(a)
+		if err != nil {
+			return nil, err
+		}
+		switch kind {
+		case "file":
+			if err := add(a); err != nil {
+				return nil, err
+			}
+		case "pattern":
+			hasPattern = true
+			patterns = append(patterns, a)
+			files, err := walkTobariJSON(base)
+			if err != nil {
+				return nil, fmt.Errorf("failed to walk %s: %w", a, err)
+			}
+			for _, f := range files {
+				if err := add(f); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	if hasPattern && len(out) == 0 {
+		return nil, fmt.Errorf("no tobari/tobari.json files found under patterns: %v", patterns)
+	}
+	return out, nil
 }

--- a/internal/cli/merge_cmd_test.go
+++ b/internal/cli/merge_cmd_test.go
@@ -30,11 +30,185 @@ func TestRunMergeCmd_UnknownSubcommand(t *testing.T) {
 	}
 }
 
-func TestRunMergeJSONCmd_TooFewInputs(t *testing.T) {
+func TestRunMergeJSONCmd_NoInputs(t *testing.T) {
 	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
-	err := c.runMergeJSONCmd(context.Background(), []string{"only-one.json"})
-	if err == nil || !strings.Contains(err.Error(), "at least two input files") {
-		t.Errorf("expected input count error, got: %v", err)
+	err := c.runMergeJSONCmd(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "missing input") {
+		t.Errorf("expected missing input error, got: %v", err)
+	}
+}
+
+func TestClassifyMergeArg(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantKind string
+		wantBase string
+		wantErr  bool
+	}{
+		{"./...", "pattern", ".", false},
+		{"./foo/...", "pattern", "foo", false},
+		{"pkg/...", "pattern", "pkg", false},
+		{"/abs/path/...", "pattern", "/abs/path", false},
+		{"a.json", "file", "", false},
+		{"some/dir/tobari.json", "file", "", false},
+		{"...", "", "", true},
+		{"-o", "", "", true},
+		{"/...", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			kind, base, err := classifyMergeArg(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got kind=%q base=%q", kind, base)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if kind != tc.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tc.wantKind)
+			}
+			if base != tc.wantBase {
+				t.Errorf("base = %q, want %q", base, tc.wantBase)
+			}
+		})
+	}
+}
+
+func TestRunMergeJSONCmd_PatternWalk(t *testing.T) {
+	dir := t.TempDir()
+
+	// Two valid tobari.json files under packages.
+	writeJSONAt(t, filepath.Join(dir, "svc1", "tobari", "tobari.json"),
+		minimalReport("TestSvc1", "/src/svc1/main.go"))
+	writeJSONAt(t, filepath.Join(dir, "svc2", "tobari", "tobari.json"),
+		minimalReport("TestSvc2", "/src/svc2/main.go"))
+
+	// Noise that must NOT be picked up.
+	if err := os.MkdirAll(filepath.Join(dir, "svc3"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "svc3", "notes.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// tobari.json directly under a package, parent is not "tobari" dir.
+	writeJSONAt(t, filepath.Join(dir, "svc4", "tobari.json"),
+		minimalReport("TestSvc4", "/src/svc4/main.go"))
+	// vendor/ should be skipped.
+	writeJSONAt(t, filepath.Join(dir, "vendor", "x", "tobari", "tobari.json"),
+		minimalReport("TestVendor", "/src/vendor/main.go"))
+	// Dot-prefixed dir should be skipped.
+	writeJSONAt(t, filepath.Join(dir, ".hidden", "tobari", "tobari.json"),
+		minimalReport("TestHidden", "/src/hidden/main.go"))
+
+	outputPath := filepath.Join(dir, "out.json")
+	var stdout bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &bytes.Buffer{}}
+	if err := c.runMergeJSONCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "..."),
+	}); err != nil {
+		t.Fatalf("runMergeJSONCmd() error = %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Merged 2 reports") {
+		t.Errorf("stdout = %q, want to contain 'Merged 2 reports'", stdout.String())
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	var merged tobari.CoverReport
+	if err := json.Unmarshal(data, &merged); err != nil {
+		t.Fatalf("failed to parse merged output: %v", err)
+	}
+	if len(merged.Counts) != 2 {
+		t.Errorf("counts = %d, want 2 (svc1+svc2 only)", len(merged.Counts))
+	}
+	gotNames := map[string]bool{}
+	for _, cnt := range merged.Counts {
+		gotNames[cnt.Name] = true
+	}
+	for _, want := range []string{"TestSvc1", "TestSvc2"} {
+		if !gotNames[want] {
+			t.Errorf("missing test %q in merged result: %v", want, gotNames)
+		}
+	}
+	for _, bad := range []string{"TestSvc4", "TestVendor", "TestHidden"} {
+		if gotNames[bad] {
+			t.Errorf("unexpected test %q in merged result", bad)
+		}
+	}
+}
+
+func TestRunMergeJSONCmd_PatternMixed(t *testing.T) {
+	dir := t.TempDir()
+
+	writeJSONAt(t, filepath.Join(dir, "a", "tobari", "tobari.json"),
+		minimalReport("TestA", "/src/a/main.go"))
+	writeJSONAt(t, filepath.Join(dir, "extra.json"),
+		minimalReport("TestExtra", "/src/extra/main.go"))
+
+	outputPath := filepath.Join(dir, "out.json")
+	var stdout bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &bytes.Buffer{}}
+	if err := c.runMergeJSONCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "a", "..."),
+		filepath.Join(dir, "extra.json"),
+	}); err != nil {
+		t.Fatalf("runMergeJSONCmd() error = %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Merged 2 reports") {
+		t.Errorf("stdout = %q, want to contain 'Merged 2 reports'", stdout.String())
+	}
+}
+
+func TestRunMergeJSONCmd_PatternDedup(t *testing.T) {
+	dir := t.TempDir()
+
+	writeJSONAt(t, filepath.Join(dir, "a", "b", "tobari", "tobari.json"),
+		minimalReport("TestAB", "/src/ab/main.go"))
+
+	outputPath := filepath.Join(dir, "out.json")
+	var stdout bytes.Buffer
+	c := &CLI{stdout: &stdout, stderr: &bytes.Buffer{}}
+	if err := c.runMergeJSONCmd(context.Background(), []string{
+		"-o", outputPath,
+		filepath.Join(dir, "a", "..."),
+		filepath.Join(dir, "a", "b", "..."),
+	}); err != nil {
+		t.Fatalf("runMergeJSONCmd() error = %v", err)
+	}
+
+	// The single file must not be counted twice.
+	if !strings.Contains(stdout.String(), "Merged 1 reports") {
+		t.Errorf("stdout = %q, want to contain 'Merged 1 reports' (dedup)", stdout.String())
+	}
+}
+
+func TestRunMergeJSONCmd_PatternNoMatches(t *testing.T) {
+	dir := t.TempDir()
+
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeJSONCmd(context.Background(), []string{
+		"-o", filepath.Join(dir, "out.json"),
+		filepath.Join(dir, "..."),
+	})
+	if err == nil || !strings.Contains(err.Error(), "no tobari/tobari.json files found") {
+		t.Errorf("expected no-matches error, got: %v", err)
+	}
+}
+
+func TestRunMergeJSONCmd_BareEllipsis(t *testing.T) {
+	c := &CLI{stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+	err := c.runMergeJSONCmd(context.Background(), []string{"..."})
+	if err == nil || !strings.Contains(err.Error(), "bare '...'") {
+		t.Errorf("expected bare ellipsis error, got: %v", err)
 	}
 }
 
@@ -291,6 +465,37 @@ func writeJSON(t *testing.T, dir, name string, report tobari.CoverReport) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// writeJSONAt writes a CoverReport as JSON to the given absolute path,
+// creating parent directories as needed.
+func writeJSONAt(t *testing.T, path string, report tobari.CoverReport) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// minimalReport returns a minimal valid CoverReport for pattern-walk tests.
+func minimalReport(testName, file string) tobari.CoverReport {
+	return tobari.CoverReport{
+		Metadata: tobari.CoverReportMetadata{
+			Files: []string{file},
+			Entry: []string{"FileName", "StartLine", "StartCol", "EndLine", "EndCol", "StatementCount"},
+			All:   [][]int{{0, 1, 1, 2, 1, 1}},
+		},
+		Counts: []*tobari.CoverReportCount{
+			{Name: testName, Coverprofile: [][]int{{0, 1}}},
+		},
+		AllCounts: []int{1},
 	}
 }
 


### PR DESCRIPTION
## Summary

- `tobari merge json` now accepts Go package patterns like `./...` or `./foo/...` alongside literal file paths. Pattern arguments walk the filesystem recursively and pick up every `tobari/tobari.json` file under the base, skipping `vendor/` and dot/underscore-prefixed directories. Symbolic links are not followed.
- After running `go test ./...`, each package leaves its own `tobari/tobari.json`. Previously they had to be enumerated by hand; now `tobari merge json -o merged.json ./...` is enough.
- Mixed mode is supported: `tobari merge json ./foo/... ./bar/tobari/tobari.json extra.json`. Duplicates discovered through overlapping patterns are deduped by absolute path.

## Behavior details

- `...` alone is rejected (`bare '...' is not allowed; use './...'`).
- `/...` (filesystem root) is rejected to avoid accidental whole-disk walks.
- A pattern that matches zero `tobari/tobari.json` files yields a clear `no tobari/tobari.json files found under patterns: ...` error.
- The minimum-input check is relaxed from "two or more" to "at least one"; the existing `TestRunMergeJSONCmd_TooFewInputs` is replaced by `TestRunMergeJSONCmd_NoInputs`.
- Output default stays `merged.json`, which does not match the `tobari/tobari.json` suffix, so re-running `tobari merge json ./...` is safe by construction. The help text adds a note advising against pointing `-o` at a path ending in `tobari/tobari.json`.

## Test plan

- [x] `go test ./internal/cli/...` (all tests pass, including the new `TestClassifyMergeArg`, `TestRunMergeJSONCmd_PatternWalk`, `_PatternMixed`, `_PatternDedup`, `_PatternNoMatches`, `_BareEllipsis`)
- [x] Manual e2e with a temp tree containing `svc1/tobari/tobari.json`, `svc2/tobari/tobari.json`, plus noise (`svc4/tobari.json` with wrong parent dir, `vendor/x/tobari/tobari.json`, `.hidden/tobari/tobari.json`) — only svc1 and svc2 are picked up.
- [x] Manual e2e for mixed pattern + literal arguments.
- [x] Manual e2e for error paths: bare `...`, `/...`, empty directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)