### PR TITLE
Add --exclude-analysis flag and fix nondeterministic dependency analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,42 @@ GOFLAGS="$(tobari flags -tags=timetzdata)" go build .
 This example shows distinguishing coverage results by name, but you can also use it the same way as `runtime/coverage`.
 For specific APIs, please [refer here](https://pkg.go.dev/github.com/goccy/tobari).
 
+### Speeding Up the Dependency Analysis
+
+When the main package is built, tobari runs a whole-program call-graph analysis
+(RTA) to determine which lines are reachable from each coverage-target function.
+This analysis is superlinear in the number of reachable types and interface call
+sites, so a dependency closure containing a large amount of generated code — such
+as gRPC/protobuf clients — can make it slow.
+
+If your build takes too long and you know which packages are irrelevant to the
+analysis, `--exclude-analysis` can help. It takes comma-separated package path
+prefixes to leave out:
+
+```console
+GOFLAGS="$(tobari flags -exclude-analysis=github.com/org/repo)" go build .
+
+# Multiple prefixes
+GOFLAGS="$(tobari flags -exclude-analysis=github.com/org/repo,github.com/org/other)" go build .
+```
+
+A prefix matches the package itself and everything beneath it, so a single entry
+can exclude a whole generated tree, while a deeper prefix excludes just one
+sub-package.
+
+Coverage-target packages (those instrumented via `-coverpkg`, `go test ./...`, and
+so on) and the main package are never excluded, even if a prefix matches them:
+they are what the analysis exists to measure. Naming one is silently ignored.
+
+> **Correctness requirement**: only exclude packages that never call back into a
+> coverage-target package — that is, packages you never hand a callback, an
+> interface value, or any other value carrying your code. Generated gRPC clients
+> that only marshal request/response data qualify. If an excluded package *does*
+> call back into coverage-target code, the dependency edges through it are lost
+> and coverage denominators will be too small. Excluding a package changes the
+> build cache key for coverage-instrumented packages only, so toggling it
+> rebuilds those without invalidating the rest of the dependency closure.
+
 ### Embedding Source Code
 
 Tobari supports embedding the original source code into instrumented binaries with the `--embed-code` (`-E`) option. This is useful for archiving the exact source that was compiled, enabling offline coverage analysis without access to the original source tree.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,9 +36,11 @@ func (c *CLI) Run(ctx context.Context, args []string) error {
 	tobariBinPath := args[0]
 
 	// Parse tobari-specific flags before the tool path.
-	// When invoked as: tobari [--embed-code] [--build-tags=VALUE] /path/to/compile <args>
+	// When invoked as: tobari [--embed-code] [--build-tags=VALUE]
+	//                         [--exclude-analysis=PREFIX,...] /path/to/compile <args>
 	embedCode := false
 	buildTags := ""
+	var excludeAnalysis []string
 	i := 1
 	for i < len(args) {
 		if args[i] == "--embed-code" {
@@ -46,6 +48,9 @@ func (c *CLI) Run(ctx context.Context, args []string) error {
 			i++
 		} else if strings.HasPrefix(args[i], "--build-tags=") {
 			buildTags = strings.TrimPrefix(args[i], "--build-tags=")
+			i++
+		} else if strings.HasPrefix(args[i], "--exclude-analysis=") {
+			excludeAnalysis = utils.ParsePkgPrefixes(strings.TrimPrefix(args[i], "--exclude-analysis="))
 			i++
 		} else {
 			break
@@ -69,8 +74,9 @@ func (c *CLI) Run(ctx context.Context, args []string) error {
 	// toolexec passes Go tool's absolute path as args[1]
 	if isToolexecCall(arg1) {
 		return tool.Handle(ctx, args, tool.BuildOpts{
-			EmbedCode: embedCode,
-			BuildTags: buildTags,
+			EmbedCode:       embedCode,
+			BuildTags:       buildTags,
+			ExcludeAnalysis: excludeAnalysis,
 		})
 	}
 

--- a/internal/cli/flags_cmd.go
+++ b/internal/cli/flags_cmd.go
@@ -14,17 +14,18 @@ func (c *CLI) runFlagsCmd(ctx context.Context, tobariBinPath string, args []stri
 	embedCode := fs.Bool("embed-code", false, "embed source code into the instrumented binary")
 	fs.BoolVar(embedCode, "E", false, "embed source code into the instrumented binary (shorthand)")
 	tags := fs.String("tags", "", "build tags (same as go build -tags)")
+	excludeAnalysis := fs.String("exclude-analysis", "", "comma-separated package path prefixes to exclude from dependency analysis")
 
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	for _, arg := range fs.Args() {
 		if strings.HasPrefix(arg, "-") {
-			return fmt.Errorf("flags must be specified before other arguments\nUsage: tobari flags [--embed-code | -E] [-tags=VALUE]")
+			return fmt.Errorf("flags must be specified before other arguments\nUsage: tobari flags [--embed-code | -E] [-tags=VALUE] [-exclude-analysis=PREFIX,...]")
 		}
 	}
 
-	out, err := flags.Run(ctx, tobariBinPath, *embedCode, *tags)
+	out, err := flags.Run(ctx, tobariBinPath, *embedCode, *tags, *excludeAnalysis)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/help_cmd.go
+++ b/internal/cli/help_cmd.go
@@ -24,6 +24,10 @@ Flags:
 Flags Command Options:
     --embed-code, -E    Embed original source code into the instrumented binary
     -tags=VALUE         Build tags (same as go build -tags)
+    -exclude-analysis=PKGS
+                        Comma-separated package path prefixes to exclude from the
+                        whole-program dependency analysis. Only exclude packages
+                        that never call back into coverage-target code.
 
 HTML Command Options:
     -o <file>           Output HTML file path (default: cover.html)
@@ -49,6 +53,9 @@ Merge Command:
 
 Toolexec Options (used with -toolexec):
     --embed-code        Embed original source code into the instrumented binary
+    --exclude-analysis=PKGS
+                        Comma-separated package path prefixes to exclude from the
+                        whole-program dependency analysis
 
 Examples:
     # Get flags for go build

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -27,7 +27,7 @@ import (
 	"github.com/goccy/tobari/internal/utils"
 )
 
-func Run(ctx context.Context, args []string, embedCode bool) error {
+func Run(ctx context.Context, args []string, embedCode bool, excludeAnalysis []string) error {
 	inputFiles, opt, err := parseOption(args)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func Run(ctx context.Context, args []string, embedCode bool) error {
 		// Write suppDeps to the $WORK/bNNN/ directory alongside _testmain.go.
 		// This prevents races when go test ./... builds multiple packages in
 		// parallel, as each package gets its own isolated file.
-		if err := createAndWriteSuppDeps(nil, true, pkgcfg, filepath.Dir(inputFiles[0])); err != nil {
+		if err := createAndWriteSuppDeps(nil, true, pkgcfg, filepath.Dir(inputFiles[0]), excludeAnalysis); err != nil {
 			return err
 		}
 	} else if pkgcfg.PkgName == "main" {
@@ -99,7 +99,7 @@ func Run(ctx context.Context, args []string, embedCode bool) error {
 			if opt.pkgcfg != "" {
 				workDir = filepath.Dir(opt.pkgcfg)
 			}
-			if err := createAndWriteSuppDeps(inputFiles, false, nil, workDir); err != nil {
+			if err := createAndWriteSuppDeps(inputFiles, false, nil, workDir, excludeAnalysis); err != nil {
 				return err
 			}
 		}
@@ -1225,8 +1225,8 @@ func (b *Buffer) Bytes() []byte {
 // testPkgCfg provides the package config for directory resolution.
 // workDir, when non-empty, specifies the directory to write the suppDeps
 // file to (used in testmain mode to avoid races in parallel builds).
-func createAndWriteSuppDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *PackageConfig, workDir string) error {
-	suppDeps, err := CreateMainDeps(mainSourceFiles, isTestMode, testPkgCfg)
+func createAndWriteSuppDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *PackageConfig, workDir string, excludeAnalysis []string) error {
+	suppDeps, err := CreateMainDeps(mainSourceFiles, isTestMode, testPkgCfg, excludeAnalysis)
 	if err != nil {
 		return err
 	}

--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -330,7 +330,15 @@ func collectAnonymFuncsFromInfo(fset *token.FileSet, file *ast.File, body *ast.B
 // so that RTA can trace call edges through third-party libraries.
 // For test mode, -test is added to go list to include test dependencies.
 // Returns nil if no coverage-target packages are found.
-func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *PackageConfig) (map[string][]string, error) {
+//
+// excludeAnalysis lists package-path prefixes whose SSA bodies are not built,
+// making RTA treat them as opaque leaves. This is a caller assertion that the
+// excluded packages never call back into coverage-target code (see the
+// --exclude-analysis flag). It exists because whole-program RTA is superlinear
+// in the number of reachable types and interface call sites: on large services
+// the generated gRPC/protobuf client packages dominate the analysis while
+// contributing no cover→cover edges.
+func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *PackageConfig, excludeAnalysis []string) (map[string][]string, error) {
 	tobariBin, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tobari binary path: %w", err)
@@ -420,19 +428,44 @@ func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *Packa
 
 	prog, _ := ssautil.AllPackages(pkgs, ssa.InstantiateGenerics)
 
-	// Build SSA for ALL packages.
-	prog.Build()
+	if len(excludeAnalysis) == 0 {
+		// Build SSA for ALL packages.
+		prog.Build()
+	} else {
+		// Build SSA for every package except the excluded ones. Excluded
+		// packages stay bodyless, so RTA cannot trace calls through them; the
+		// caller asserts they never re-enter cover code.
+		for _, ssaPkg := range prog.AllPackages() {
+			if ssaPkg.Pkg == nil {
+				continue
+			}
+			if !isMainPkg(ssaPkg) && isExcludedFromAnalysis(ssaPkg.Pkg.Path(), excludeAnalysis, coverPkgSet) {
+				continue
+			}
+			ssaPkg.Build()
+		}
+	}
 
 	// Collect RTA roots from main/test packages and cover-target packages.
+	//
+	// The iteration order must be deterministic: prog.AllPackages() and
+	// ssa.Package.Members are backed by maps, and rta.Analyze gives roots[0]
+	// special treatment (callgraph.New(roots[0]) is the only place a node is
+	// created for a root that has no call edges). An unstable order therefore
+	// makes edge-less roots appear in, or vanish from, the resulting suppDeps.
+	ssaPkgs := prog.AllPackages()
+	sort.Slice(ssaPkgs, func(i, j int) bool {
+		return ssaPkgPath(ssaPkgs[i]) < ssaPkgPath(ssaPkgs[j])
+	})
+
 	var roots []*ssa.Function
-	for _, ssaPkg := range prog.AllPackages() {
+	for _, ssaPkg := range ssaPkgs {
 		if ssaPkg.Pkg == nil {
 			continue
 		}
 		pkgPath := ssaPkg.Pkg.Path()
-		isMainOrTest := pkgPath == "main" || strings.HasSuffix(pkgPath, ".test") || strings.Contains(pkgPath, " [")
 		_, isCoverTarget := coverPkgSet[pkgPath]
-		if !isMainOrTest && !isCoverTarget {
+		if !isMainOrTestPkg(pkgPath) && !isMainPkg(ssaPkg) && !isCoverTarget {
 			continue
 		}
 		if mainFunc := ssaPkg.Func("main"); mainFunc != nil {
@@ -441,8 +474,13 @@ func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *Packa
 		if initFunc := ssaPkg.Func("init"); initFunc != nil {
 			roots = append(roots, initFunc)
 		}
-		for name, member := range ssaPkg.Members {
-			fn, ok := member.(*ssa.Function)
+		names := make([]string, 0, len(ssaPkg.Members))
+		for name := range ssaPkg.Members {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			fn, ok := ssaPkg.Members[name].(*ssa.Function)
 			if !ok {
 				continue
 			}
@@ -464,20 +502,73 @@ func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *Packa
 	graph := rtaResult.CallGraph
 
 	// Build dependency map for coverage-target packages.
+	//
+	// Iterate the reachable set rather than the call graph's nodes: RTA only
+	// creates a graph node for a function that participates in a call edge (plus
+	// roots[0], which callgraph.New materializes). A reachable cover function
+	// with no cover-relevant edges would otherwise be included or omitted
+	// depending on where it happened to land in the root list.
 	suppDeps := make(map[string][]string)
-	for _, n := range graph.Nodes {
-		if n.Func == nil {
+	for fn := range rtaResult.Reachable {
+		if funcCoverPkgPath(fn, coverPkgSet) == "" {
 			continue
 		}
-		if funcCoverPkgPath(n.Func, coverPkgSet) == "" {
-			continue
+		fnName := normalizeFuncName(fn)
+		var deps []string
+		if n := graph.Nodes[fn]; n != nil {
+			deps = analyzeMainFuncDeps(coverPkgSet, n)
 		}
-		fnName := normalizeFuncName(n.Func)
-		deps := analyzeMainFuncDeps(coverPkgSet, n)
 		suppDeps[fnName] = mergeDeps(suppDeps[fnName], deps)
 	}
 
 	return suppDeps, nil
+}
+
+// isExcludedFromAnalysis reports whether a package's SSA body may be skipped.
+//
+// A package is excluded only when it matches one of the caller's prefixes AND
+// it is not needed to produce the dependency map. Coverage-target packages and
+// the main/test entry points are never excluded, even if a prefix matches them:
+// they are the source of the cover→cover edges the analysis exists to find, and
+// dropping their bodies would silently shrink coverage denominators. Since
+// --exclude-analysis is meant for packages irrelevant to the analysis, naming a
+// coverage target is a user mistake that is ignored rather than honored.
+func isExcludedFromAnalysis(pkgPath string, excludeAnalysis []string, coverPkgSet map[string]struct{}) bool {
+	if !utils.MatchesPkgPrefix(pkgPath, excludeAnalysis) {
+		return false
+	}
+	if isMainOrTestPkg(pkgPath) {
+		return false
+	}
+	// matchCoverPkg also resolves test variants ("pkg [pkg.test]").
+	return matchCoverPkg(pkgPath, coverPkgSet) == ""
+}
+
+// isMainOrTestPkg reports whether a package path denotes the main package or a
+// test binary / test variant package.
+//
+// Note that a main package's import path is normally its module path, not the
+// literal "main"; use isMainPkg when an *ssa.Package is available.
+func isMainOrTestPkg(pkgPath string) bool {
+	return pkgPath == "main" ||
+		strings.HasSuffix(pkgPath, ".test") ||
+		strings.Contains(pkgPath, " [")
+}
+
+// isMainPkg reports whether an SSA package is a main package. This checks the
+// package name because `go list` reports a main package's import path as its
+// module path (e.g. "example.com/app"), not "main".
+func isMainPkg(ssaPkg *ssa.Package) bool {
+	return ssaPkg.Pkg != nil && ssaPkg.Pkg.Name() == "main"
+}
+
+// ssaPkgPath returns an SSA package's import path, or "" for the synthetic
+// package with no types.Package. Used to sort packages deterministically.
+func ssaPkgPath(ssaPkg *ssa.Package) string {
+	if ssaPkg.Pkg == nil {
+		return ""
+	}
+	return ssaPkg.Pkg.Path()
 }
 
 // coverPkgSetResult holds cover package paths discovered from the global cache.
@@ -549,7 +640,11 @@ func resolveGoListDir(mainSourceFiles []string, testPkgCfg *PackageConfig) (stri
 			if err := json.Unmarshal(data, &cache); err != nil || cache.Dir == "" {
 				continue
 			}
-			if modulePath != "" && !strings.HasPrefix(cache.PkgPath, modulePath) {
+			// Match on package-path boundaries. A plain prefix test would let
+			// module "example.com/foo" claim the cover targets of the unrelated
+			// module "example.com/foobar", whose entries share the same global
+			// cache. Picking a foreign directory then yields a bogus go list dir.
+			if modulePath != "" && !utils.MatchesPkgPrefix(cache.PkgPath, []string{modulePath}) {
 				continue
 			}
 			if cache.PkgPath == lookupPath {

--- a/internal/cover/exclude_test.go
+++ b/internal/cover/exclude_test.go
@@ -1,0 +1,68 @@
+package cover
+
+import "testing"
+
+func TestIsExcludedFromAnalysis(t *testing.T) {
+	coverPkgSet := map[string]struct{}{
+		"example.com/app/handler": {},
+		"example.com/app/store":   {},
+	}
+	prefixes := []string{
+		"example.com/app/store",    // a coverage target: must be ignored
+		"example.com/app/handler",  // a coverage target: must be ignored
+		"github.com/org/generated", // irrelevant third party: excluded
+		"example.com/app/internal/x",
+	}
+
+	tests := []struct {
+		name string
+		pkg  string
+		want bool
+	}{
+		{"third party matching prefix is excluded", "github.com/org/generated", true},
+		{"subpackage of excluded third party", "github.com/org/generated/pb/v1", true},
+		{"non-cover internal package matching prefix", "example.com/app/internal/x", true},
+
+		{"coverage target is never excluded", "example.com/app/store", false},
+		{"coverage target (handler) is never excluded", "example.com/app/handler", false},
+		{"test variant of a coverage target is never excluded", "example.com/app/store [example.com/app.test]", false},
+
+		{"main is never excluded", "main", false},
+		{"test binary is never excluded", "example.com/app.test", false},
+
+		{"package not matching any prefix", "example.com/app/other", false},
+		{"string-prefix trap", "github.com/org/generatedx", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isExcludedFromAnalysis(tt.pkg, prefixes, coverPkgSet); got != tt.want {
+				t.Errorf("isExcludedFromAnalysis(%q) = %v, want %v", tt.pkg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsExcludedFromAnalysisNoPrefixes(t *testing.T) {
+	if isExcludedFromAnalysis("github.com/org/generated", nil, nil) {
+		t.Error("no prefixes must never exclude")
+	}
+}
+
+func TestIsMainOrTestPkg(t *testing.T) {
+	tests := []struct {
+		pkg  string
+		want bool
+	}{
+		{"main", true},
+		{"example.com/app.test", true},
+		{"example.com/app/store [example.com/app.test]", true},
+		{"example.com/app/store", false},
+		{"maintenance", false},
+	}
+	for _, tt := range tests {
+		if got := isMainOrTestPkg(tt.pkg); got != tt.want {
+			t.Errorf("isMainOrTestPkg(%q) = %v, want %v", tt.pkg, got, tt.want)
+		}
+	}
+}

--- a/internal/cover/golistdir_test.go
+++ b/internal/cover/golistdir_test.go
@@ -1,0 +1,73 @@
+package cover
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goccy/tobari/internal/utils"
+)
+
+// writeCoverPkgCache seeds the global cover-package cache with one entry.
+func writeCoverPkgCache(t *testing.T, pkgPath, dir string) {
+	t.Helper()
+	cacheDir := utils.CoverPkgsDir()
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	data, err := json.Marshal(coverPkgCache{PkgPath: pkgPath, Dir: dir})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, coverPkgDirHash(dir)), data, 0o644); err != nil {
+		t.Fatalf("write cache entry: %v", err)
+	}
+}
+
+// TestResolveGoListDirModuleBoundary verifies that a module only claims cover
+// targets from its own package path, not from a module whose path merely shares
+// a string prefix. The cover-package cache is global, so entries from unrelated
+// modules ("example.com/foobar") coexist with the module under analysis
+// ("example.com/foo"). Matching without a path boundary used to pick a foreign
+// directory and derive a go list directory containing no Go files.
+func TestResolveGoListDirModuleBoundary(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+
+	// A cover target belonging to the *unrelated* module example.com/foobar.
+	foreignRoot := filepath.Join(tmp, "foobar")
+	foreignPkg := filepath.Join(foreignRoot, "handler")
+	if err := os.MkdirAll(foreignPkg, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignRoot, "go.mod"), []byte("module example.com/foobar\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	writeCoverPkgCache(t, "example.com/foobar/handler", foreignPkg)
+
+	cfg := &PackageConfig{PkgPath: "example.com/foo.test", ModulePath: "example.com/foo"}
+	dir, err := resolveGoListDir(nil, cfg)
+	if err == nil {
+		t.Fatalf("expected no directory for example.com/foo, got %q (leaked from example.com/foobar)", dir)
+	}
+
+	// Now add a cover target that genuinely belongs to example.com/foo.
+	ownRoot := filepath.Join(tmp, "foo")
+	ownPkg := filepath.Join(ownRoot, "store")
+	if err := os.MkdirAll(ownPkg, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ownRoot, "go.mod"), []byte("module example.com/foo\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	writeCoverPkgCache(t, "example.com/foo/store", ownPkg)
+
+	dir, err = resolveGoListDir(nil, cfg)
+	if err != nil {
+		t.Fatalf("expected to resolve dir for example.com/foo: %v", err)
+	}
+	if dir != ownRoot {
+		t.Errorf("resolveGoListDir = %q, want %q", dir, ownRoot)
+	}
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func Run(ctx context.Context, tobariBinPath string, embedCode bool, tags string) (string, error) {
+func Run(ctx context.Context, tobariBinPath string, embedCode bool, tags, excludeAnalysis string) (string, error) {
 	path, err := exec.LookPath(tobariBinPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to find tobari binary path from %s: %w", tobariBinPath, err)
@@ -26,6 +26,9 @@ func Run(ctx context.Context, tobariBinPath string, embedCode bool, tags string)
 	}
 	if tags != "" {
 		toolexecValue += " --build-tags=" + tags
+	}
+	if excludeAnalysis != "" {
+		toolexecValue += " --exclude-analysis=" + excludeAnalysis
 	}
 	toolexecFlag := "-toolexec=" + toolexecValue
 	if strings.Contains(toolexecValue, " ") {

--- a/internal/tool/build.go
+++ b/internal/tool/build.go
@@ -23,6 +23,9 @@ func tobariToolexec(opts BuildOpts) (string, error) {
 	if opts.BuildTags != "" {
 		v += " --build-tags=" + opts.BuildTags
 	}
+	if len(opts.ExcludeAnalysis) != 0 {
+		v += " --exclude-analysis=" + strings.Join(opts.ExcludeAnalysis, ",")
+	}
 	return v, nil
 }
 

--- a/internal/tool/cover.go
+++ b/internal/tool/cover.go
@@ -8,9 +8,9 @@ import (
 	"github.com/goccy/tobari/internal/cover"
 )
 
-func handleCover(ctx context.Context, toolPath string, args []string, embedCode bool) error {
+func handleCover(ctx context.Context, toolPath string, args []string, embedCode bool, excludeAnalysis []string) error {
 	if !isCoverVOption(args) && !containsSelfPackageFile(args) {
-		return cover.Run(ctx, args, embedCode)
+		return cover.Run(ctx, args, embedCode, excludeAnalysis)
 	}
 	runCommand(toolPath, args)
 	return nil

--- a/internal/tool/driver.go
+++ b/internal/tool/driver.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
@@ -127,8 +128,14 @@ func HandlePackagesDriver(ctx context.Context, patterns []string) error {
 
 	// Build roots: main package, cover targets, and test packages.
 	rootSet := make(map[string]struct{})
-	if _, ok := pkgMap["main"]; ok {
-		rootSet["main"] = struct{}{}
+	// The main package must be identified by its package name, not by its
+	// import path: `go list` reports a main package's ImportPath as its module
+	// path (e.g. "example.com/app"), never the literal "main". Without this the
+	// main package is not loaded at all, so RTA cannot trace from main.
+	for _, glp := range goListPkgs {
+		if glp.Name == "main" {
+			rootSet[glp.ImportPath] = struct{}{}
+		}
 	}
 	for pkgPath := range coverPkgPaths {
 		if _, ok := pkgMap[pkgPath]; ok {
@@ -146,6 +153,9 @@ func HandlePackagesDriver(ctx context.Context, patterns []string) error {
 	for id := range rootSet {
 		roots = append(roots, id)
 	}
+	// Deterministic order: packages.Load's roots feed RTA root ordering, and
+	// callgraph.New(roots[0]) treats the first root specially.
+	sort.Strings(roots)
 
 	var pkgList []*packages.Package
 	for _, dp := range pkgMap {

--- a/internal/tool/handler.go
+++ b/internal/tool/handler.go
@@ -2,6 +2,8 @@ package tool
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -37,7 +39,7 @@ func Handle(ctx context.Context, args []string, opts BuildOpts) error {
 			return err
 		}
 	case "cover":
-		if err := handleCover(ctx, toolPath, toolArgs, opts.EmbedCode); err != nil {
+		if err := handleCover(ctx, toolPath, toolArgs, opts.EmbedCode, opts.ExcludeAnalysis); err != nil {
 			return err
 		}
 	default:
@@ -83,7 +85,28 @@ func handleVersionFull(ctx context.Context, toolPath string, args []string, opts
 	// - opt: invalidates cache when toolexec options change (e.g., --embed-code)
 	// Note: trimpath and race are excluded from opt because they are detected later
 	// from compiler args and Go already includes them in its own cache key.
-	fmt.Printf("%s tobari:[version:%s overlay:%s opt:%s]\n",
-		strings.TrimSpace(string(org)), ver.ID(), overlayHash, opts.Hash())
+	ident := fmt.Sprintf("version:%s overlay:%s opt:%s", ver.ID(), overlayHash, opts.Hash())
+
+	// -exclude-analysis only changes the suppDeps produced by the cover tool, so
+	// it is folded into the *cover* tool's identity alone. Go probes -V=full per
+	// tool, and each tool's identity feeds the actionID of the packages built
+	// with it. Adding this to the compile tool's identity instead would
+	// invalidate the entire dependency closure, even though only the
+	// cover-instrumented packages and main can change.
+	//
+	// It cannot be handled at compile time instead: on a cache hit Go skips the
+	// toolexec invocation entirely, so nothing written during compile can affect
+	// the hit/miss decision. The identity probe is the only pre-action input.
+	if filepath.Base(toolPath) == "cover" && len(opts.ExcludeAnalysis) != 0 {
+		ident += " exclude-analysis:" + hashStrings(opts.ExcludeAnalysis)
+	}
+
+	fmt.Printf("%s tobari:[%s]\n", strings.TrimSpace(string(org)), ident)
 	return nil
+}
+
+// hashStrings returns a short stable hash of a string slice.
+func hashStrings(v []string) string {
+	h := sha256.Sum256([]byte(strings.Join(v, "\x00")))
+	return hex.EncodeToString(h[:])[:16]
 }

--- a/internal/tool/opts.go
+++ b/internal/tool/opts.go
@@ -13,12 +13,22 @@ type BuildOpts struct {
 	Trimpath  bool
 	Race      bool
 	BuildTags string
+	// ExcludeAnalysis lists package-path prefixes to omit from the
+	// whole-program dependency analysis. See cover.CreateMainDeps.
+	ExcludeAnalysis []string
 }
 
 // Hash returns a short hash derived from the toolexec options that affect
 // code generation (EmbedCode, BuildTags). Trimpath and Race are excluded
 // because they are detected later from compiler args and Go already
 // includes them in its own cache key.
+//
+// ExcludeAnalysis is deliberately NOT hashed here. This hash is emitted for
+// every tool's `-V=full` probe, so it feeds the actionID of every package
+// compiled with that tool; hashing ExcludeAnalysis here would invalidate the
+// whole dependency closure even though only cover-instrumented packages can
+// change. It is folded into the cover tool's identity alone instead; see
+// handleVersionFull.
 func (o BuildOpts) Hash() string {
 	s := fmt.Sprintf("build-tags=%s,embed-code=%v", o.BuildTags, o.EmbedCode)
 	h := sha256.Sum256([]byte(s))

--- a/internal/utils/go.go
+++ b/internal/utils/go.go
@@ -47,7 +47,6 @@ const (
 	TmpHTMLDirPattern = "tobari_html_*"
 )
 
-
 func GoRoot() (string, error) {
 	// check GOROOT environment variable first (set by toolchain switching)
 	if root := os.Getenv("GOROOT"); root != "" {
@@ -219,9 +218,11 @@ func GoListDepsJSON(dir string, isTest bool, pkg string) ([]byte, error) {
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = dir
 	cmd.Env = FilterGOFLAGSEnvs()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to run go list -deps: %w", err)
+		return nil, fmt.Errorf("failed to run go list -deps in %s: %w: %s", dir, err, strings.TrimSpace(stderr.String()))
 	}
 	return out, nil
 }
@@ -259,6 +260,29 @@ func FilterGOFLAGSEnvs() []string {
 		newEnvs = append(newEnvs, kv)
 	}
 	return newEnvs
+}
+
+// ParsePkgPrefixes splits a comma-separated list of package-path prefixes,
+// trimming whitespace and dropping empty entries.
+func ParsePkgPrefixes(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// MatchesPkgPrefix reports whether pkgPath equals one of the prefixes or is a
+// subpackage of one (prefix + "/").
+func MatchesPkgPrefix(pkgPath string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if pkgPath == p || strings.HasPrefix(pkgPath, p+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // ImportsFromSource extracts import packages from Go source.

--- a/internal/utils/pkgprefix_test.go
+++ b/internal/utils/pkgprefix_test.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePkgPrefixes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "github.com/org/repo", []string{"github.com/org/repo"}},
+		{
+			"multiple",
+			"github.com/org/repo/internal/foo,github.com/org/other/pb",
+			[]string{"github.com/org/repo/internal/foo", "github.com/org/other/pb"},
+		},
+		{
+			"trims spaces and drops empties",
+			" github.com/org/a , ,github.com/org/b ,",
+			[]string{"github.com/org/a", "github.com/org/b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParsePkgPrefixes(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParsePkgPrefixes(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesPkgPrefix(t *testing.T) {
+	// A sub-package prefix must exclude only that package and its descendants,
+	// never a sibling, a parent, or a package that merely shares a string prefix.
+	prefixes := ParsePkgPrefixes("github.com/org/foo,github.com/org/repo/internal/foo,github.com/org/other/pb")
+
+	tests := []struct {
+		pkg  string
+		want bool
+	}{
+		{"github.com/org/foo", true},       // exact match
+		{"github.com/org/foo/sub", true},   // descendant
+		{"github.com/org/foobar", false},   // string-prefix trap: foo vs foobar
+		{"github.com/org/foobar/x", false}, // descendant of the trap sibling
+
+		{"github.com/org/repo/internal/foo", true},      // exact match
+		{"github.com/org/repo/internal/foo/deep", true}, // descendant
+		{"github.com/org/other/pb", true},               // second prefix
+		{"github.com/org/repo/internal/bar", false},     // sibling
+		{"github.com/org/repo/internal", false},         // parent
+		{"github.com/org/repo", false},                  // module root
+		{"github.com/org/other/pbx", false},             // string-prefix trap
+		{"github.com/org/otherpb", false},               // string-prefix trap
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := MatchesPkgPrefix(tt.pkg, prefixes); got != tt.want {
+			t.Errorf("MatchesPkgPrefix(%q) = %v, want %v", tt.pkg, got, tt.want)
+		}
+	}
+}
+
+func TestMatchesPkgPrefixNoPrefixes(t *testing.T) {
+	if MatchesPkgPrefix("github.com/org/repo", nil) {
+		t.Error("no prefixes must never match")
+	}
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -1002,4 +1003,130 @@ func createTestTarGzData(t *testing.T, files map[string]string) []byte {
 		t.Fatalf("close gzip writer: %v", err)
 	}
 	return buf.Bytes()
+}
+
+// TestSuppDepsDeterministic verifies that repeated builds of the same program
+// produce identical supplementary dependency data.
+//
+// The analysis derives its roots from maps (ssa.Program.AllPackages and
+// ssa.Package.Members), and rta.Analyze materializes a call-graph node for
+// roots[0] even when that root has no call edges. An unstable root order
+// therefore used to add or drop entries from suppDeps between builds, silently
+// changing coverage denominators.
+func TestSuppDepsDeterministic(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari")
+
+	if out, err := exec.CommandContext(ctx, "go", "build", "-o", tobariBin, "./cmd/tobari").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+
+	const runs = 5
+	var first string
+	for i := range runs {
+		got := buildCrosspkgSuppDeps(t, ctx, tobariBin, "")
+		if i == 0 {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Fatalf("suppDeps differ between builds\nrun 1: %s\nrun %d: %s", first, i+1, got)
+		}
+	}
+}
+
+// TestExcludeAnalysisIgnoresCoverTargets verifies that naming a coverage-target
+// package in --exclude-analysis is ignored: its SSA is still built and its
+// dependency edges are preserved. Excluding a genuinely irrelevant package, by
+// contrast, must not affect a coverage target's edges either. In both cases the
+// suppDeps must equal the baseline (no exclusion) for this program, whose cover
+// targets only pass plain data across package boundaries.
+func TestExcludeAnalysisIgnoresCoverTargets(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari")
+	if out, err := exec.CommandContext(ctx, "go", "build", "-o", tobariBin, "./cmd/tobari").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+
+	baseline := buildCrosspkgSuppDeps(t, ctx, tobariBin, "")
+
+	tests := []struct {
+		name    string
+		exclude string
+	}{
+		{"exclude a coverage-target package (must be ignored)", "example.com/crosspkg/transform"},
+		{"exclude all coverage-target packages (all ignored)", "example.com/crosspkg"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildCrosspkgSuppDeps(t, ctx, tobariBin, tt.exclude)
+			if got != baseline {
+				t.Errorf("excluding %q changed suppDeps (coverage target should be ignored)\nbaseline: %s\ngot:      %s",
+					tt.exclude, baseline, got)
+			}
+		})
+	}
+}
+
+// buildCrosspkgSuppDeps builds testdata/crosspkg with tobari and returns the
+// suppDeps JSON embedded in the resulting binary. A fresh Go build cache forces
+// the cover tool (and thus the analysis) to run again; a fresh cover-package
+// cache keeps the discovered coverage targets identical across builds. When
+// excludeAnalysis is non-empty it is passed via --exclude-analysis.
+func buildCrosspkgSuppDeps(t *testing.T, ctx context.Context, tobariBin, excludeAnalysis string) string {
+	t.Helper()
+	if err := os.RemoveAll(coverPkgsDir()); err != nil {
+		t.Fatalf("failed to clear cover pkg cache: %v", err)
+	}
+	toolexec := tobariBin
+	if excludeAnalysis != "" {
+		toolexec += " --exclude-analysis=" + excludeAnalysis
+	}
+	bin := filepath.Join(t.TempDir(), "app")
+	cmd := exec.CommandContext(ctx, "go", "build",
+		"-cover", "-toolexec="+toolexec, "-o", bin, ".")
+	cmd.Dir = "testdata/crosspkg"
+	cmd.Env = append(os.Environ(), "GOCACHE="+t.TempDir())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %s: %v", string(out), err)
+	}
+	return extractSuppDeps(t, bin)
+}
+
+// coverPkgsDir mirrors utils.CoverPkgsDir, which is in an internal package.
+func coverPkgsDir() string {
+	return filepath.Join(os.TempDir(), "tobari", "coverpkgs")
+}
+
+// extractSuppDeps returns the suppDeps JSON object embedded in a tobari-built
+// binary. The cover tool serializes the map and the compile tool bakes it in as
+// a string literal, so it appears verbatim in the binary's data section.
+func extractSuppDeps(t *testing.T, binPath string) string {
+	t.Helper()
+	data, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("failed to read binary: %v", err)
+	}
+	// Locate the JSON object whose first key is a crosspkg function.
+	marker := []byte(`{"`)
+	for i := 0; i+len(marker) < len(data); i++ {
+		if !bytes.HasPrefix(data[i:], marker) {
+			continue
+		}
+		end := bytes.IndexByte(data[i:], '}')
+		if end < 0 {
+			continue
+		}
+		candidate := data[i : i+end+1]
+		if !bytes.Contains(candidate, []byte("example.com/crosspkg")) {
+			continue
+		}
+		var m map[string][]string
+		if err := json.Unmarshal(candidate, &m); err != nil {
+			continue // a nested object; keep scanning
+		}
+		return string(candidate)
+	}
+	t.Fatal("suppDeps not found in binary")
+	return ""
 }


### PR DESCRIPTION
## Summary

Adds an `--exclude-analysis` option and fixes three latent bugs in the
main-package dependency analysis that were uncovered while validating it.

### `--exclude-analysis`

When the main package is built, tobari runs a whole-program call-graph analysis
(RTA) to compute, per coverage-target function, which lines are reachable. This
analysis is superlinear in the number of reachable types and interface call
sites, so a dependency closure containing a large amount of generated code
(e.g. gRPC/protobuf clients) can make it slow.

`--exclude-analysis` takes comma-separated package path prefixes to omit from the
analysis. It is available both via `tobari flags -exclude-analysis=...` and
directly as a toolexec flag.

```console
GOFLAGS="$(tobari flags -exclude-analysis=github.com/org/repo)" go build .

# Multiple prefixes; a deeper prefix excludes a single sub-package
GOFLAGS="$(tobari flags -exclude-analysis=github.com/org/repo,github.com/org/other/pb)" go build .
```

Safety properties:

- **Coverage targets and main are never excluded.** Packages instrumented via
  `-coverpkg` / `go test`, and the main package, are kept even if a prefix
  matches them — naming one is simply ignored.
- **Cache invalidation is scoped.** The option is folded into the *cover* tool's
  `-V=full` build-cache identity only, so toggling it rebuilds the
  coverage-instrumented packages without invalidating the rest of the dependency
  closure. (Putting it in the shared compile identity would recompile the whole
  closure; leaving it out entirely would serve a stale binary on a cache hit.)
- **Boundary matching.** Prefixes match on package-path boundaries, so
  `github.com/org/foo` does not match `github.com/org/foobar`.

> **Correctness requirement:** only exclude packages that never call back into a
> coverage-target package (no callbacks, interface values, or other values
> carrying your code handed to them). Generated gRPC clients that only marshal
> request/response data qualify. Excluding a genuine bridge package drops the
> dependency edges through it and undercounts coverage denominators.

### Bug fixes (found while validating the flag)

These caused `suppDeps` — and therefore coverage denominators — to vary between
otherwise identical builds:

1. **main was never loaded into the analysis.** `go list` reports a main
   package's import path as its module path, not the literal `"main"`, so the
   GOPACKAGESDRIVER and root detection never matched it and RTA could not trace
   from `main`. Both now identify main by package name.
2. **RTA roots were collected in nondeterministic map order.** `rta.Analyze`
   only materializes a call-graph node for `roots[0]` when that root has no call
   edges, so an edge-less root would appear in or vanish from `suppDeps`
   depending on ordering. Roots are now ordered deterministically, and the
   dependency map is derived from RTA's `Reachable` set rather than from
   `roots[0]`.
3. **`resolveGoListDir` used a boundary-less prefix match.** Module
   `example.com/foo` could claim cover-cache entries left by the unrelated
   module `example.com/foobar` (the cache is global), producing a `go list`
   directory with no Go files. It now matches on package-path boundaries.

## Tests

- Unit tests: prefix boundary matching (including the `foo` / `foobar` trap), the
  coverage-target exclusion guard, and module-boundary directory resolution.
- End-to-end tests: `suppDeps` is byte-identical across repeated builds, and is
  unchanged when a coverage-target package is named in `--exclude-analysis`.
- `go list` failures now surface the underlying stderr.

All were verified to fail when the corresponding fix is reverted. Full test
suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
