### PR TITLE
Fix nil pointer dereference from concurrent DepRefs mutation in resolveCandidateFuncMap

### DIFF
--- a/internal/tobari/tobari.go
+++ b/internal/tobari/tobari.go
@@ -237,20 +237,9 @@ func resolveCandidateFuncMap(fn *Function, fnMap map[*Function]struct{}) {
 	}
 
 	fnMap[fn] = struct{}{}
-	funcMapMu.RLock()
-	for _, dep := range fn.Deps {
-		ref, exists := funcMap[dep]
-		if !exists {
-			// funcMap is the ground truth for packages instrumented in this
-			// binary (populated via AddCoverMeta at init time). suppDeps may
-			// reference functions from packages that are in the global cover
-			// cache but not instrumented in this binary. Use funcMap as the
-			// runtime coverPkgSet and skip deps outside of it.
-			continue
-		}
-		fn.DepRefs = append(fn.DepRefs, ref)
-	}
-	funcMapMu.RUnlock()
+	// DepRefs is resolved once by decodeRawMetas and immutable afterwards, so
+	// this traversal is safe without locking even when multiple goroutines
+	// build coverprofiles concurrently.
 	for _, ref := range fn.DepRefs {
 		resolveCandidateFuncMap(ref, fnMap)
 	}
@@ -666,6 +655,28 @@ func decodeRawMetas() {
 			pendingSuppDeps = nil
 		}
 		pendingSuppDepsMu.Unlock()
+
+		// Resolve Deps into DepRefs exactly once. DepRefs must not be built
+		// lazily at query time: coverprofile queries run concurrently, and
+		// appending to a shared Function from multiple goroutines corrupts
+		// the slice. After this point DepRefs is immutable.
+		funcMapMu.Lock()
+		for _, fn := range funcMap {
+			for _, dep := range fn.Deps {
+				ref, exists := funcMap[dep]
+				if !exists {
+					// funcMap is the ground truth for packages instrumented
+					// in this binary (populated via AddCoverMeta at init
+					// time). suppDeps may reference functions from packages
+					// that are in the global cover cache but not instrumented
+					// in this binary. Use funcMap as the runtime coverPkgSet
+					// and skip deps outside of it.
+					continue
+				}
+				fn.DepRefs = append(fn.DepRefs, ref)
+			}
+		}
+		funcMapMu.Unlock()
 	})
 }
 

--- a/internal/tobari/tobari_test.go
+++ b/internal/tobari/tobari_test.go
@@ -1,0 +1,128 @@
+package tobari
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+const (
+	testFuncNum   = 300
+	testDepFanout = 6
+	testFileName  = "example.go"
+)
+
+var testCoverMetaOnce sync.Once
+
+func testFuncName(i int) string {
+	return fmt.Sprintf("example.com/pkg.Fn%d", i)
+}
+
+// setupTestCoverMeta registers coverage metadata for a synthetic package of
+// testFuncNum functions where each function depends on the next
+// testDepFanout functions, then returns a TraceEntry whose trace hit the
+// first block of Fn0. Resolving candidate functions for that entry walks the
+// whole dependency chain.
+func setupTestCoverMeta(t *testing.T) *TraceEntry {
+	t.Helper()
+	testCoverMetaOnce.Do(func() {
+		md := &Metadata{
+			FileName:   testFileName,
+			PkgPath:    "example.com/pkg",
+			PkgName:    "pkg",
+			ModulePath: "example.com",
+		}
+		suppDeps := make(map[string][]string)
+		for i := 0; i < testFuncNum; i++ {
+			name := testFuncName(i)
+			md.Funcs = append(md.Funcs, &Function{
+				Name: name,
+				Blocks: []*Block{
+					{
+						Idx:      i,
+						Start:    Pos{Line: i + 1, Col: 1},
+						End:      Pos{Line: i + 1, Col: 10},
+						NumStmts: 1,
+					},
+				},
+			})
+			for j := 1; j <= testDepFanout && i+j < testFuncNum; j++ {
+				suppDeps[name] = append(suppDeps[name], testFuncName(i+j))
+			}
+		}
+		suppDepsJSON, err := json.Marshal(suppDeps)
+		if err != nil {
+			panic(err)
+		}
+		AddCoverMeta(MarshalMetadata(md))
+		AddSupplementaryDeps(string(suppDepsJSON))
+		decodeRawMetas()
+	})
+
+	root := newTraceG(1)
+	root.addCounter(blockID(testFileName, 0))
+	return &TraceEntry{Name: "dep-resolution", Roots: []*TraceG{root}}
+}
+
+// depRefsLen returns the current DepRefs length of every registered function
+// and fails the test if any DepRefs slice contains a nil element.
+func depRefsLen(t *testing.T) map[string]int {
+	t.Helper()
+	funcMapMu.RLock()
+	defer funcMapMu.RUnlock()
+	ret := make(map[string]int, len(funcMap))
+	for name, fn := range funcMap {
+		for i, ref := range fn.DepRefs {
+			if ref == nil {
+				t.Fatalf("function %s has nil DepRefs element at index %d (len=%d)", name, i, len(fn.DepRefs))
+			}
+		}
+		ret[name] = len(fn.DepRefs)
+	}
+	return ret
+}
+
+// Concurrent CoverprofileMap calls must not race on the shared Function
+// dependency graph. Before the fix, resolveCandidateFuncMap appended to
+// fn.DepRefs under a read lock, so concurrent calls corrupted the slice and
+// crashed with a nil pointer dereference while recursing over DepRefs.
+func TestCoverprofileMapConcurrentDepResolution(t *testing.T) {
+	entry := setupTestCoverMeta(t)
+
+	const (
+		goroutineNum = 16
+		iterations   = 300
+	)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutineNum; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				entry.CoverprofileMap()
+			}
+		}()
+	}
+	wg.Wait()
+
+	depRefsLen(t)
+}
+
+// Repeated CoverprofileMap calls must not keep growing fn.DepRefs. Before the
+// fix, every call re-appended the same resolved references because the
+// visited set was per-call while DepRefs persisted on the shared Function.
+func TestCoverprofileMapRepeatedCallsKeepDepRefsStable(t *testing.T) {
+	entry := setupTestCoverMeta(t)
+
+	entry.CoverprofileMap()
+	before := depRefsLen(t)
+	entry.CoverprofileMap()
+	after := depRefsLen(t)
+
+	for name, beforeLen := range before {
+		if afterLen := after[name]; afterLen != beforeLen {
+			t.Errorf("function %s: DepRefs grew from %d to %d across CoverprofileMap calls", name, beforeLen, afterLen)
+		}
+	}
+}

--- a/testdata/concurrentquery/go.mod
+++ b/testdata/concurrentquery/go.mod
@@ -1,0 +1,7 @@
+module example.com/concurrentquery
+
+go 1.24.0
+
+require github.com/goccy/tobari v0.0.0
+
+replace github.com/goccy/tobari => ../..

--- a/testdata/concurrentquery/go.sum
+++ b/testdata/concurrentquery/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/testdata/concurrentquery/main.go
+++ b/testdata/concurrentquery/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"example.com/concurrentquery/worker"
+)
+
+func main() {
+	fmt.Println(worker.Run(8))
+}

--- a/testdata/concurrentquery/main_test.go
+++ b/testdata/concurrentquery/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/goccy/tobari"
+
+	"example.com/concurrentquery/worker"
+)
+
+// TestConcurrentCoverageQueries mirrors a long-running server that records
+// traces and then exports coverage from many goroutines at once: traces are
+// recorded first, then concurrent goroutines repeatedly render the
+// coverprofile. Each render resolves the supplementary dependency graph, so
+// any unsynchronized mutation of shared coverage-runtime state surfaces here.
+// The e2e suite runs this test under the race detector, which the outer
+// `go test -race` cannot do for the runtime injected into child binaries.
+func TestConcurrentCoverageQueries(t *testing.T) {
+	for range 4 {
+		tobari.Cover(func() {
+			if got := worker.Run(8); got == 0 {
+				t.Fatal("unexpected zero result from worker.Run")
+			}
+		})
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				tobari.WriteCoverprofile(tobari.SetMode, io.Discard)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/testdata/concurrentquery/mathops/mathops.go
+++ b/testdata/concurrentquery/mathops/mathops.go
@@ -1,0 +1,27 @@
+package mathops
+
+func Sum(nums []int) int {
+	total := 0
+	for _, n := range nums {
+		total += n
+	}
+	return total
+}
+
+func Scale(nums []int, factor int) []int {
+	scaled := make([]int, len(nums))
+	for i, n := range nums {
+		scaled[i] = n * factor
+	}
+	return scaled
+}
+
+func Clamp(n, min, max int) int {
+	if n < min {
+		return min
+	}
+	if n > max {
+		return max
+	}
+	return n
+}

--- a/testdata/concurrentquery/worker/worker.go
+++ b/testdata/concurrentquery/worker/worker.go
@@ -1,0 +1,17 @@
+package worker
+
+import "example.com/concurrentquery/mathops"
+
+// Run exercises cross-package calls so that the whole-program dependency
+// analysis produces non-empty supplementary deps for this function. The
+// coverage runtime then resolves those deps on every coverprofile query,
+// which is the code path the concurrent test targets.
+func Run(n int) int {
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = i + 1
+	}
+	scaled := mathops.Scale(nums, 3)
+	total := mathops.Sum(scaled)
+	return mathops.Clamp(total, 1, 1<<30)
+}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -1130,3 +1130,31 @@ func extractSuppDeps(t *testing.T, binPath string) string {
 	t.Fatal("suppDeps not found in binary")
 	return ""
 }
+
+// TestCoverageRuntimeRaceClean verifies that the coverage runtime injected into
+// user binaries is race-clean when coverage is queried from concurrent
+// goroutines. The repository's own `go test -race` cannot observe that runtime
+// because it executes inside tobari-built child binaries, so this test builds
+// testdata/concurrentquery with tobari and runs its test under the race
+// detector. A fresh build cache and cover-package cache force the cover tool
+// and the whole-program dependency analysis to run, so the supplementary deps
+// are populated — the runtime's dependency-resolution path is exercised only
+// when they are.
+func TestCoverageRuntimeRaceClean(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari")
+	if out, err := exec.CommandContext(ctx, "go", "build", "-o", tobariBin, "./cmd/tobari").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+	if err := os.RemoveAll(coverPkgsDir()); err != nil {
+		t.Fatalf("failed to clear cover pkg cache: %v", err)
+	}
+	cmd := exec.CommandContext(ctx, "go", "test", "-race", "-count=1",
+		"-cover", "-toolexec="+tobariBin,
+		"-coverpkg=example.com/concurrentquery/...", ".")
+	cmd.Dir = "testdata/concurrentquery"
+	cmd.Env = append(os.Environ(), "GOCACHE="+t.TempDir())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go test -race failed: %s: %v", string(out), err)
+	}
+}


### PR DESCRIPTION
## Problem

Concurrent coverprofile queries could crash with:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation ...]
github.com/goccy/tobari/internal/tobari.resolveCandidateFuncMap(0x0, ...)
        internal/tobari/tobari.go:241
github.com/goccy/tobari/internal/tobari.resolveCandidateFuncMap(...)
        internal/tobari/tobari.go:255
```

Two defects in `resolveCandidateFuncMap` caused this:

1. **Data race on `Function.DepRefs`.** The function lazily appended resolved dependency references to the shared `Function.DepRefs` slice while holding only `funcMapMu.RLock()`, and then iterated the slice after releasing the lock. Read locks admit multiple holders, so concurrent `CoverprofileMap` calls appended to (and iterated) the same slice simultaneously. The racing slice-header updates can expose zero-valued (nil) elements, and recursing into a nil `*Function` dereferences it at `fn.Deps`.

2. **Unbounded duplicate growth.** The visited set (`hitCandidateFuncMap`) is created per `CoverprofileMap` call, while `DepRefs` persists on the shared `Function`. Every call therefore re-appended the same references, growing `DepRefs` without bound and increasing the frequency of racy slice reallocations.

## Fix

Resolve `Deps` into `DepRefs` exactly once in `decodeRawMetas`, after pending supplementary deps are applied, while holding `funcMapMu` for writing. `DepRefs` is immutable afterwards, so `resolveCandidateFuncMap` becomes a pure read-only traversal with no locking and no mutation.

## Tests

- `TestCoverprofileMapConcurrentDepResolution` reproduces the crash before the fix (SIGSEGV with the exact stack above, and a data-race report under `-race`); passes after the fix.
- `TestCoverprofileMapRepeatedCallsKeepDepRefsStable` fails before the fix (`DepRefs grew from 6 to 12 across CoverprofileMap calls`); passes after the fix.
- `go test ./internal/tobari/ -race` passes.

Note: `TestCacheBehavior/with_cache/{toolchain,crosspkg}` currently fails with a `github.com/goccy/tobari` fingerprint mismatch at link time both on this branch and on unmodified `main` in the same environment (identical fingerprints in both cases), so it is a pre-existing issue unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI hardening

The repository's own `go test -race` only races the tool code: the coverage runtime executes inside tobari-built child binaries, which the e2e suite compiles without `-race`. Races in the injected runtime were therefore structurally undetectable by CI.

This PR adds `TestCoverageRuntimeRaceClean` plus `testdata/concurrentquery`: an app whose test records traces via `tobari.Cover` and then renders the coverprofile from many goroutines at once. The e2e builds it with tobari and runs the test under the race detector, using `-coverpkg` and fresh build/cover-package caches so the whole-program dependency analysis actually populates supplementary deps (the runtime's dependency-resolution path is only exercised when they are non-empty).

Verified in both directions: with the `DepRefs` fix reverted, the test fails with a data race report pointing at the removed append (`internal/tobari/tobari.go:251`); with the fix it passes (~18s).
