### PR TITLE
Key the tobari pkgs cache by version to fix fingerprint mismatch across resolutions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Content-hash-keyed caches that survive Go build cache hits (when the cover/compi
 
 | Directory | Key | Purpose |
 |---|---|---|
-| `cache/` | Runtime export filename (SHA256) | tobari package export paths by build config |
+| `cache/` | Runtime export filename (SHA256) + tobari version ID | tobari package export paths by build config and tobari resolution |
 | `coverpkgs/` | Package directory path (SHA256) | Registry of coverage-target packages |
 | `overlay/<content_hash>/` | Overlay file content (SHA256, 16 chars) | Modified runtime/testing/testdeps packages |
 

--- a/internal/tool/app.go
+++ b/internal/tool/app.go
@@ -86,11 +86,14 @@ func createGoMod(path string, ver *version.Version, lang string) error {
 		return fmt.Errorf("failed to add go stmt: %w", err)
 	}
 	if ver.LocalPath != "" {
-		rel, err := filepath.Rel(path, ver.LocalPath)
-		if err != nil {
-			return fmt.Errorf("failed to create relative path from %s: %w", path, err)
-		}
-		if err := f.AddReplace("github.com/goccy/tobari", "", rel, ""); err != nil {
+		// Use the absolute path in the replace directive. A relative path
+		// would have to be computed against the go.mod's directory, but Go
+		// resolves the module root through symlinks (e.g. macOS's
+		// /var -> /private/var for $WORK under $TMPDIR), so a lexically
+		// correct relative path can point at the wrong directory. The temp
+		// module is ephemeral and never leaves this machine, so an absolute
+		// path is both safe and unambiguous.
+		if err := f.AddReplace("github.com/goccy/tobari", "", ver.LocalPath, ""); err != nil {
 			return fmt.Errorf("failed to add replace directive: %w", err)
 		}
 	} else {

--- a/internal/tool/build.go
+++ b/internal/tool/build.go
@@ -29,20 +29,29 @@ func tobariToolexec(opts BuildOpts) (string, error) {
 	return v, nil
 }
 
-func getTobariPkgs(args []string, opts BuildOpts) (map[string]string, error) {
+// effectiveTobariVersion resolves which tobari version the current build
+// links against. The target module's tobari version takes precedence over the
+// binary's version: when the tobari binary is built with one version but the
+// target application depends on a different version, using the binary's
+// version would cause fingerprint mismatches at link time because the
+// overlay-modified runtime packages would reference tobari packages at the
+// binary's version while the target links against its own version.
+//
+// Both the compile phase (which builds tobari and saves the pkgs cache) and
+// the link phase (which loads it) must resolve the version the same way, so
+// the version ID can serve as part of the cache key.
+func effectiveTobariVersion() (*version.Version, error) {
 	ver, err := version.Get()
 	if err != nil {
 		return nil, err
 	}
-	// Prefer the target module's tobari version over the binary's version.
-	// When the tobari binary is built with one version but the target application
-	// depends on a different version, using the binary's version would cause
-	// fingerprint mismatches at link time because the overlay-modified runtime
-	// packages would reference tobari packages at the binary's version while
-	// the target links against its own version.
 	if targetVer := resolveTargetTobariVersion(); targetVer != nil {
 		ver = targetVer
 	}
+	return ver, nil
+}
+
+func getTobariPkgs(args []string, opts BuildOpts, ver *version.Version) (map[string]string, error) {
 	workDir, err := workDirFromArgs(args)
 	if err != nil {
 		return nil, err

--- a/internal/tool/cache.go
+++ b/internal/tool/cache.go
@@ -33,17 +33,25 @@ func getRuntimeExportPath(importcfgPath string) string {
 }
 
 // saveTobariPkgsCache writes the tobari package map to cache locations keyed by
-// the runtime package's export file. This enables the link phase to find the
-// correct tobari packages without knowing which build flags were used.
+// the runtime package's export file and the tobari version. This enables the
+// link phase to find the correct tobari packages without knowing which build
+// flags were used.
 //
 // Two cache locations are written:
-//  1. $TMPDIR/tobari/cache/<runtime_cache_filename>.json
+//  1. $TMPDIR/tobari/cache/<runtime_cache_filename>_<tobari_version_id>.json
 //     Used when the link phase references cached packages from the Go build cache.
 //     The runtime export filename in Go's build cache is the SHA256 of the file
-//     content, so it uniquely identifies the build configuration.
+//     content, so it uniquely identifies the build configuration. The tobari
+//     version ID distinguishes builds that share a build configuration but
+//     resolve tobari differently: a target module may pin tobari to a local
+//     replace or a specific version while other builds on the same machine use
+//     the binary's version. Those produce tobari packages with different
+//     fingerprints, and mixing them up fails the link.
 //  2. <dir_of_runtime_work_path>/tobari_pkgs.json
-//     Used within the same build where compile and link share the same $WORK directory.
-func saveTobariPkgsCache(compileImportcfgPath string, pkgs map[string]string) error {
+//     Used within the same build where compile and link share the same $WORK
+//     directory. A single build resolves exactly one tobari version, so this
+//     file needs no version suffix.
+func saveTobariPkgsCache(compileImportcfgPath string, pkgs map[string]string, tobariVerID string) error {
 	// Get runtime's path from the compile importcfg (this is a $WORK/bNN/_pkg_.a path)
 	runtimeWorkPath := getRuntimeExportPath(compileImportcfgPath)
 	if runtimeWorkPath == "" {
@@ -61,12 +69,12 @@ func saveTobariPkgsCache(compileImportcfgPath string, pkgs map[string]string) er
 		return fmt.Errorf("failed to marshal tobari pkgs cache: %w", err)
 	}
 
-	// Write to cache/<runtime_cache_filename>.json
+	// Write to cache/<runtime_cache_filename>_<tobari_version_id>.json
 	cacheDir := filepath.Join(utils.TobariTempDir(), "cache")
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create cache dir: %w", err)
 	}
-	cacheFile := filepath.Join(cacheDir, filepath.Base(runtimeCachePath)+".json")
+	cacheFile := filepath.Join(cacheDir, pkgsCacheFileName(runtimeCachePath, tobariVerID))
 	_ = os.WriteFile(cacheFile, data, 0o600)
 
 	// Write to <dir_of_runtime_work_path>/tobari_pkgs.json
@@ -77,21 +85,22 @@ func saveTobariPkgsCache(compileImportcfgPath string, pkgs map[string]string) er
 }
 
 // loadTobariPkgsCache attempts to load the cached tobari package map using the
-// runtime package's path from the link importcfg.
+// runtime package's path from the link importcfg and the tobari version the
+// current build resolves to.
 //
 // It tries two cache locations:
-//  1. $TMPDIR/tobari/cache/<filename_of_runtime>.json — hits when the link phase
-//     references cached packages from Go's build cache.
+//  1. $TMPDIR/tobari/cache/<filename_of_runtime>_<tobari_version_id>.json —
+//     hits when the link phase references cached packages from Go's build cache.
 //  2. <dir_of_runtime>/tobari_pkgs.json — hits within the same build where compile
 //     and link share the same $WORK directory.
-func loadTobariPkgsCache(linkImportcfgPath string) (map[string]string, bool) {
+func loadTobariPkgsCache(linkImportcfgPath, tobariVerID string) (map[string]string, bool) {
 	runtimePath := getRuntimeExportPath(linkImportcfgPath)
 	if runtimePath == "" {
 		return nil, false
 	}
 
-	// Try cache/<filename>.json first
-	cacheFile := filepath.Join(utils.TobariTempDir(), "cache", filepath.Base(runtimePath)+".json")
+	// Try cache/<filename>_<version_id>.json first
+	cacheFile := filepath.Join(utils.TobariTempDir(), "cache", pkgsCacheFileName(runtimePath, tobariVerID))
 	if pkgs, ok := readAndValidatePkgsCache(cacheFile); ok {
 		return pkgs, true
 	}
@@ -103,6 +112,15 @@ func loadTobariPkgsCache(linkImportcfgPath string) (map[string]string, bool) {
 	}
 
 	return nil, false
+}
+
+// pkgsCacheFileName builds the global pkgs-cache filename from the runtime
+// package's export path and the tobari version ID. Keying by both isolates
+// entries per build configuration AND per tobari resolution, so builds that
+// pin tobari differently (via the target go.mod) never read each other's
+// entries.
+func pkgsCacheFileName(runtimePath, tobariVerID string) string {
+	return filepath.Base(runtimePath) + "_" + tobariVerID + ".json"
 }
 
 func readAndValidatePkgsCache(path string) (map[string]string, bool) {

--- a/internal/tool/compile.go
+++ b/internal/tool/compile.go
@@ -108,11 +108,15 @@ func handleCompile(ctx context.Context, toolPath string, args []string, opts Bui
 		// running `go list -deps -export` (which is slow and creates the
 		// per-build app dir) would be wasted work.
 		if importCfgPath := getImportcfgPathFromArgs(args); importCfgPath != "" && !importcfgHasTobari(importCfgPath) {
-			pkgs, err := getTobariPkgs(args, opts)
+			ver, err := effectiveTobariVersion()
+			if err != nil {
+				return err
+			}
+			pkgs, err := getTobariPkgs(args, opts, ver)
 			if err != nil {
 				return fmt.Errorf("failed to build tobari packages: %w", err)
 			}
-			if err := saveTobariPkgsCache(importCfgPath, pkgs); err != nil {
+			if err := saveTobariPkgsCache(importCfgPath, pkgs, ver.ID()); err != nil {
 				return err
 			}
 			if err := overwriteImportcfg(importCfgPath, pkgs); err != nil {
@@ -204,7 +208,11 @@ SEARCH_TOBARI_PKG_END:
 		return nil
 	}
 
-	pkgs, err := getTobariPkgs(args, opts)
+	ver, err := effectiveTobariVersion()
+	if err != nil {
+		return err
+	}
+	pkgs, err := getTobariPkgs(args, opts, ver)
 	if err != nil {
 		return err
 	}

--- a/internal/tool/link.go
+++ b/internal/tool/link.go
@@ -14,9 +14,15 @@ func handleLink(ctx context.Context, toolPath string, args []string, opts BuildO
 
 	// Try to load cached tobari packages. The cache is written during the
 	// compile phase of the main package, keyed by the runtime package's
-	// export filename, which uniquely identifies the build configuration
-	// (including flags like -trimpath, -race, -tags, etc.).
-	if pkgs, ok := loadTobariPkgsCache(importCfgPath); ok {
+	// export filename — which uniquely identifies the build configuration
+	// (including flags like -trimpath, -race, -tags, etc.) — plus the tobari
+	// version this build resolves to, so builds that pin tobari differently
+	// never pick up each other's entries.
+	ver, err := effectiveTobariVersion()
+	if err != nil {
+		return err
+	}
+	if pkgs, ok := loadTobariPkgsCache(importCfgPath, ver.ID()); ok {
 		if err := overwriteImportcfg(importCfgPath, pkgs); err != nil {
 			return fmt.Errorf("failed to update importcfg: %w", err)
 		}
@@ -31,7 +37,7 @@ func handleLink(ctx context.Context, toolPath string, args []string, opts BuildO
 			EmbedCode: opts.EmbedCode,
 			BuildTags: opts.BuildTags,
 		}
-		pkgs, err := getTobariPkgs(args, fallbackOpts)
+		pkgs, err := getTobariPkgs(args, fallbackOpts, ver)
 		if err != nil {
 			return err
 		}

--- a/tobari_test.go
+++ b/tobari_test.go
@@ -1130,3 +1130,116 @@ func extractSuppDeps(t *testing.T, binPath string) string {
 	t.Fatal("suppDeps not found in binary")
 	return ""
 }
+
+// TestPkgsCacheIsolationAcrossTobariVersions verifies that the global tobari
+// pkgs cache keeps entries from builds that resolve tobari differently
+// isolated from each other. A module may pin tobari via a go.mod replace
+// directive while other builds on the same machine resolve the tobari
+// binary's own version; both share one build configuration (one runtime
+// export file), but the pinned module's tobari packages have different
+// fingerprints. If one build's cache entry can clobber the other's,
+// relinking the pinned module from a warm build cache links against the
+// wrong tobari and fails with a fingerprint mismatch.
+func TestPkgsCacheIsolationAcrossTobariVersions(t *testing.T) {
+	ctx := t.Context()
+	tobariBin := filepath.Join(t.TempDir(), "tobari")
+	if out, err := exec.CommandContext(ctx, "go", "build", "-o", tobariBin, "./cmd/tobari").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build tobari: %s: %v", string(out), err)
+	}
+
+	// Copy the runtime subset of the tobari module to a separate path. The
+	// copy is source-identical but its packages get different fingerprints
+	// because export data embeds source file positions.
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tobariCopy := filepath.Join(t.TempDir(), "tobari-copy")
+	if err := os.MkdirAll(filepath.Join(tobariCopy, "internal", "tobari"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"go.mod", "go.sum", "tobari.go", filepath.Join("internal", "tobari", "tobari.go")} {
+		data, err := os.ReadFile(filepath.Join(repoRoot, f))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(tobariCopy, f), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// An app that pins tobari to the copy, mirroring testdata/crosspkg's
+	// pattern: tobari is pinned in go.mod so the injected import resolves to
+	// the pinned path, but no source file imports it.
+	appDir := filepath.Join(t.TempDir(), "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	appGoMod := fmt.Sprintf(`module example.com/versionpin
+
+go 1.24.0
+
+require github.com/goccy/tobari v0.0.0
+
+replace github.com/goccy/tobari => %s
+`, tobariCopy)
+	appGoSum, err := os.ReadFile(filepath.Join(repoRoot, "testdata", "crosspkg", "go.sum"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	appMain := `package main
+
+import "fmt"
+
+func greeting() string {
+	return "hello"
+}
+
+func main() {
+	fmt.Println(greeting())
+}
+`
+	appTest := `package main
+
+import "testing"
+
+func TestGreeting(t *testing.T) {
+	if greeting() != "hello" {
+		t.Fatal("unexpected greeting")
+	}
+}
+`
+	for name, content := range map[string][]byte{
+		"go.mod":       []byte(appGoMod),
+		"go.sum":       appGoSum,
+		"main.go":      []byte(appMain),
+		"main_test.go": []byte(appTest),
+	} {
+		if err := os.WriteFile(filepath.Join(appDir, name), content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	gocache := t.TempDir()
+	run := func(dir string, goArgs ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "go", goArgs...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GOCACHE="+gocache,
+			"GOFLAGS=-cover -toolexec="+tobariBin,
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("go %s failed in %s: %s: %v", strings.Join(goArgs, " "), dir, string(out), err)
+		}
+	}
+
+	// Cold build of the pinned app writes its pkgs-cache entry.
+	run(appDir, "test", "-count=1", ".")
+	// A build resolving the binary's tobari version shares the same build
+	// configuration and must not clobber the pinned app's cache entry.
+	run(filepath.Join(repoRoot, "testdata", "initfunc"), "run", "main.go")
+	// Relink the pinned app from the warm build cache: the link phase must
+	// find the pinned tobari packages again.
+	run(appDir, "test", "-count=1", ".")
+}


### PR DESCRIPTION
## Problem

`TestCacheBehavior/with_cache/{toolchain,crosspkg}` failed deterministically in some environments with:

```
link: fingerprint mismatch: github.com/goccy/tobari has 75a69c601235a738, import from main expecting dc9cf1615f159a82
```

The global pkgs cache (`$TMPDIR/tobari/cache/<runtime_export_filename>.json`) was keyed only by the runtime package's export filename. That identifies the build configuration (toolchain, `-race`, `-trimpath`, tags, ...) but **not how tobari itself is resolved**. Two resolutions coexist on one machine:

- a module that pins tobari via `require`/`replace` in its go.mod (e.g. `testdata/crosspkg`, `testdata/toolchain`) builds tobari at the pinned path/version, while
- every other build resolves the tobari binary's own version (`version.Get()`).

The two produce tobari packages with different fingerprints but wrote the **same cache entry**, so the last writer clobbered the other. Relinking a pinned module from a warm Go build cache (compile replayed, link re-run) then injected the wrong tobari.

Confirmed with debug logging of the link phase: crosspkg's cold link used its own entry (local build), a later app's compile overwrote the shared key with the binary-resolved build, and crosspkg's warm relink picked that up, producing the mismatch.

## Why it only failed sometimes

The collision needs `version.Get()` to resolve to something other than the local repo path. That is true for **release binaries** (version injected via ldflags) and for dev builds at a clean release tag (VCS-stamped `v0.11.0`). Ordinary dev builds are stamped `(devel)`/pseudo-version, fall back to the local path for every build, and mask the bug, which is why CI and most local runs never caught it.

## Fix

- Resolve the effective tobari version identically in the compile phase (which saves the cache) and the link phase (which loads it): target go.mod pin first, binary version otherwise (`effectiveTobariVersion`). Append its ID to the cache filename: `<runtime_export_filename>_<tobari_version_id>.json`. Builds that resolve tobari differently now keep separate entries. The `$WORK`-local `tobari_pkgs.json` needs no suffix because one build resolves exactly one tobari version.
- Write the temp module's replace directive with the **absolute** local path. The previous relative path was computed against the go.mod file path (one `..` too many) and only worked because Go resolves the module root through symlinks (macOS `/var -> /private/var` for `$WORK`), which re-absorbed the extra level; with a replace target inside `$TMPDIR` it pointed at a nonexistent directory.
- Update the temp-file documentation in CLAUDE.md accordingly.

## Tests

- New e2e `TestPkgsCacheIsolationAcrossTobariVersions`: pins tobari to a source-identical copy of the module, interleaves a build using the binary's resolution, then relinks the pinned app from a warm build cache. Fails with the exact fingerprint mismatch without the fix; passes with it. Network-free and deterministic (no release stamping or module proxy involved).
- Manual verification with a release-stamped binary (`-ldflags -X internal/version.ver=v0.11.0`): the previously failing cold-then-warm sequence over generic/crosspkg/initfunc now passes, and the cache dir shows one entry per resolution (`..._v0.11.0.json` and `..._<localpath-hash>.json`).
- Full `go test .` (including TestCacheBehavior, TestSuppDepsDeterministic, TestFingerprintConsistency) and `go test ./internal/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
