### PR TITLE
Confirm VTA edges per caller and store deduplicated callees for the frontier walk

### DIFF
--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -529,7 +529,7 @@ func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *Packa
 	}
 	vtaGraph := vta.CallGraph(vtaFuncs, cha.CallGraph(prog))
 
-	followable := newFollowableEdges(graph, vtaGraph)
+	followable := newFollowableCallees(graph, vtaGraph)
 	frontierSets := newFrontiers(graph, followable, coverPkgSet)
 
 	// Build dependency map for coverage-target packages.
@@ -574,20 +574,23 @@ func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *Packa
 // their non-generic implementations), so requiring VTA confirmation there
 // would silently drop real dependencies. For those callees RTA's judgment
 // is kept.
-func followEdge(vtaEdges map[vtaEdge]struct{}, e *callgraph.Edge) bool {
+//
+// confirmed holds the (site, callee) pairs the VTA graph records for the
+// edge's caller; see vtaConfirmedEdges.
+func followEdge(confirmed map[vtaEdge]struct{}, e *callgraph.Edge) bool {
 	if followedWithoutVTA(e.Site, e.Callee.Func) {
 		return true
 	}
-	_, confirmed := vtaEdges[vtaEdge{site: e.Site, callee: e.Callee.Func}]
-	return confirmed
+	_, ok := confirmed[vtaEdge{site: e.Site, callee: e.Callee.Func}]
+	return ok
 }
 
 // followedWithoutVTA reports whether the policy above resolves a (site,
-// callee) pair to "follow" without consulting the VTA index.
+// callee) pair to "follow" without consulting the VTA graph.
 //
-// indexVTAEdges shares this predicate rather than repeating the
-// short-circuits, so a later change to the policy cannot leave the index
-// missing a key the policy still asks about.
+// vtaConfirmedEdges shares this predicate rather than repeating the
+// short-circuits, so a later change to the policy cannot leave the confirmed
+// set missing a pair the policy still asks about.
 func followedWithoutVTA(site ssa.CallInstruction, callee *ssa.Function) bool {
 	if site == nil {
 		return true
@@ -606,69 +609,100 @@ type vtaEdge struct {
 	callee *ssa.Function
 }
 
-// indexVTAEdges collects the VTA call site and callee pairs that followEdge
-// needs confirmation for.
+// vtaConfirmedEdges returns the (site, callee) pairs the VTA graph records
+// for the function of RTA node n, the pairs followEdge may ask about for n's
+// out-edges.
 //
-// Pairs the policy resolves on its own are left out: indexing them too would
-// add an entry per static call, which no lookup ever reads, inside the
-// compiler's memory budget.
-func indexVTAEdges(vtaGraph *callgraph.Graph) map[vtaEdge]struct{} {
-	edges := make(map[vtaEdge]struct{}, len(vtaGraph.Nodes))
-	for _, n := range vtaGraph.Nodes {
-		for _, e := range n.Out {
-			if e.Site == nil || e.Callee == nil {
-				continue
-			}
-			if followedWithoutVTA(e.Site, e.Callee.Func) {
-				continue
-			}
-			edges[vtaEdge{site: e.Site, callee: e.Callee.Func}] = struct{}{}
+// One set per caller is enough: both graphs key their nodes by the same
+// *ssa.Function and record a call under the function containing the site
+// (rta and vta both add edges as site.Parent()), so the VTA node of n.Func
+// holds every pair that could confirm an edge of n. Building the set per
+// caller keeps the scratch space bounded by one function's VTA out-degree
+// rather than by the whole VTA graph.
+//
+// Pairs the policy resolves on its own are left out, and the result is nil
+// when no edge of n needs confirmation, so a function that only makes static
+// calls — most of them — costs nothing here.
+func vtaConfirmedEdges(vtaGraph *callgraph.Graph, n *callgraph.Node) map[vtaEdge]struct{} {
+	needed := false
+	for _, e := range n.Out {
+		if !followedWithoutVTA(e.Site, e.Callee.Func) {
+			needed = true
+			break
 		}
 	}
-	return edges
+	if !needed {
+		return nil
+	}
+	caller := vtaGraph.Nodes[n.Func]
+	if caller == nil {
+		return nil
+	}
+	confirmed := make(map[vtaEdge]struct{}, len(caller.Out))
+	for _, e := range caller.Out {
+		if e.Site == nil || e.Callee == nil {
+			continue
+		}
+		if followedWithoutVTA(e.Site, e.Callee.Func) {
+			continue
+		}
+		confirmed[vtaEdge{site: e.Site, callee: e.Callee.Func}] = struct{}{}
+	}
+	return confirmed
 }
 
-// followableEdges holds, per RTA node, the out-edges the dependency traversal
-// may follow.
-type followableEdges struct {
-	out map[*callgraph.Node][]*callgraph.Edge
+// followableCallees holds, per RTA node, the distinct callees the dependency
+// traversal may step to.
+type followableCallees struct {
+	out map[*callgraph.Node][]*callgraph.Node
 }
 
-// newFollowableEdges applies the edge policy to every RTA edge once.
+// newFollowableCallees applies the edge policy to every RTA edge once and
+// records each surviving callee of a node a single time.
 //
 // followEdge depends only on the edge, so a traversal that asks per visit gets
 // the same verdict it got for every other coverage-target function that
-// reached the edge.
-func newFollowableEdges(rtaGraph, vtaGraph *callgraph.Graph) *followableEdges {
-	vtaEdges := indexVTAEdges(vtaGraph)
-	out := make(map[*callgraph.Node][]*callgraph.Edge, len(rtaGraph.Nodes))
+// reached the edge. The traversal then only needs to know which nodes it can
+// step to, and RTA records one edge per call site, so a function calling the
+// same callee from several sites is stored once instead of once per site.
+func newFollowableCallees(rtaGraph, vtaGraph *callgraph.Graph) *followableCallees {
+	out := make(map[*callgraph.Node][]*callgraph.Node, len(rtaGraph.Nodes))
 
 	// kept is scratch space so each stored slice can be allocated at its exact
-	// length; a per-node slice of capacity len(n.Out) would keep the pruned
-	// fan-out resident.
-	var kept []*callgraph.Edge
+	// length. keptIn dedupes callees within one node: a callee stamped with the
+	// current generation has already been kept for this node, which avoids
+	// clearing a map between nodes.
+	var (
+		kept       []*callgraph.Node
+		keptIn     = make(map[*callgraph.Node]int, len(rtaGraph.Nodes))
+		generation int
+	)
 	for _, n := range rtaGraph.Nodes {
 		kept = kept[:0]
+		generation++
+		confirmed := vtaConfirmedEdges(vtaGraph, n)
 		for _, e := range n.Out {
-			if followEdge(vtaEdges, e) {
-				kept = append(kept, e)
+			if !followEdge(confirmed, e) {
+				continue
 			}
+			if keptIn[e.Callee] == generation {
+				continue
+			}
+			keptIn[e.Callee] = generation
+			kept = append(kept, e.Callee)
 		}
-		if len(kept) == len(n.Out) {
-			// RTA is done building by now and the traversal only reads these,
-			// so aliasing beats a defensive copy.
-			out[n] = n.Out
+		if len(kept) == 0 {
 			continue
 		}
-		followable := make([]*callgraph.Edge, len(kept))
-		copy(followable, kept)
-		out[n] = followable
+		callees := make([]*callgraph.Node, len(kept))
+		copy(callees, kept)
+		out[n] = callees
 	}
-	return &followableEdges{out: out}
+	return &followableCallees{out: out}
 }
 
-// from returns the out-edges of n that may be followed.
-func (f *followableEdges) from(n *callgraph.Node) []*callgraph.Edge {
+// from returns the distinct callees of n the traversal may step to.
+func (f *followableCallees) from(n *callgraph.Node) []*callgraph.Node {
 	return f.out[n]
 }
 

--- a/internal/cover/frontier.go
+++ b/internal/cover/frontier.go
@@ -1,6 +1,7 @@
 package cover
 
 import (
+	"fmt"
 	"math/bits"
 	"sort"
 
@@ -112,7 +113,15 @@ type frontiers struct {
 func (fr *frontiers) notExpanded(n *callgraph.Node, coverPkgSet map[string]struct{}) (*frontierSet, bool) {
 	fn := n.Func
 	if fn != nil && funcCoverPkgPath(fn, coverPkgSet) != "" {
-		bit := fr.ci.bitOf[normalizeFuncName(fn)]
+		name := normalizeFuncName(fn)
+		bit, ok := fr.ci.bitOf[name]
+		if !ok {
+			// newCoverBitIndex ran the same predicate over the same nodes, so
+			// a missing name is a bug in this file. Failing here beats
+			// silently recording bit 0 — a different function — as the
+			// dependency.
+			panic(fmt.Sprintf("tobari: coverage target %s has no bit in the frontier index", name))
+		}
 		set := make([]uint64, fr.ci.words)
 		set[bit/64] |= 1 << uint(bit%64)
 		return &frontierSet{bits: set}, true
@@ -124,7 +133,7 @@ func (fr *frontiers) notExpanded(n *callgraph.Node, coverPkgSet map[string]struc
 	return nil, false
 }
 
-func newFrontiers(rtaGraph *callgraph.Graph, followable *followableEdges, coverPkgSet map[string]struct{}) *frontiers {
+func newFrontiers(rtaGraph *callgraph.Graph, followable *followableCallees, coverPkgSet map[string]struct{}) *frontiers {
 	fr := &frontiers{
 		ci:     newCoverBitIndex(rtaGraph, coverPkgSet),
 		byNode: make(map[*callgraph.Node]*frontierSet, len(rtaGraph.Nodes)),
@@ -133,13 +142,13 @@ func newFrontiers(rtaGraph *callgraph.Graph, followable *followableEdges, coverP
 
 	// A node the walk stops at contributes its own frontier and is never
 	// expanded, so the grouping below must not see its out-edges either.
-	stops := make(map[*callgraph.Node]*frontierSet, len(rtaGraph.Nodes))
+	stops := make(map[*callgraph.Node]*frontierSet)
 	for _, n := range rtaGraph.Nodes {
 		if set, ok := fr.notExpanded(n, coverPkgSet); ok {
 			stops[n] = set
 		}
 	}
-	edgesOf := func(n *callgraph.Node) []*callgraph.Edge {
+	calleesOf := func(n *callgraph.Node) []*callgraph.Node {
 		if _, ok := stops[n]; ok {
 			return nil
 		}
@@ -149,20 +158,22 @@ func newFrontiers(rtaGraph *callgraph.Graph, followable *followableEdges, coverP
 	// Group the nodes that can all reach each other, iteratively so that a deep
 	// graph cannot exhaust the stack. Each group is completed only after every
 	// group it points at, so its frontier can be assembled on the spot.
+	//
+	// A node's frontier is assigned the moment its group is settled, so
+	// byNode doubles as the bookkeeping for the grouping: a visited node whose
+	// frontier is still nil is on the pending stack, and a node the current
+	// group points at whose frontier is still nil is a member of the group.
 	type frame struct {
-		node  *callgraph.Node
-		edges []*callgraph.Edge
-		next  int
+		node    *callgraph.Node
+		callees []*callgraph.Node
+		next    int
 	}
 	var (
-		order     = make(map[*callgraph.Node]int, len(rtaGraph.Nodes))
-		low       = make(map[*callgraph.Node]int, len(rtaGraph.Nodes))
-		open      = make(map[*callgraph.Node]bool, len(rtaGraph.Nodes))
-		groupOf   = make(map[*callgraph.Node]int, len(rtaGraph.Nodes))
-		pending   []*callgraph.Node
-		frames    []*frame
-		counter   int
-		nextGroup int
+		order   = make(map[*callgraph.Node]int, len(rtaGraph.Nodes))
+		low     = make(map[*callgraph.Node]int, len(rtaGraph.Nodes))
+		pending []*callgraph.Node
+		frames  []frame
+		counter int
 	)
 
 	begin := func(n *callgraph.Node) {
@@ -170,33 +181,24 @@ func newFrontiers(rtaGraph *callgraph.Graph, followable *followableEdges, coverP
 		low[n] = counter
 		counter++
 		pending = append(pending, n)
-		open[n] = true
-		frames = append(frames, &frame{node: n, edges: edgesOf(n)})
+		frames = append(frames, frame{node: n, callees: calleesOf(n)})
 	}
 
 	// settle assigns one frontier to every member of a completed group: the
 	// union of the frontiers of everything the group points at from outside
 	// itself.
 	settle := func(members []*callgraph.Node) {
-		id := nextGroup
-		nextGroup++
-		// Numbered first so that the loops below can tell an edge that leaves
-		// the group from one that stays inside it.
-		for _, m := range members {
-			groupOf[m] = id
-		}
-
 		contributions := func(yield func(*frontierSet)) {
 			for _, m := range members {
 				if set, ok := stops[m]; ok {
 					yield(set)
 					continue
 				}
-				for _, e := range followable.from(m) {
-					if groupOf[e.Callee] == id {
-						continue // stays inside; adds nothing to what we are building
-					}
-					if set := fr.byNode[e.Callee]; set != nil {
+				for _, callee := range followable.from(m) {
+					// Every group this one points at was settled before it,
+					// so a callee without a frontier yet is a member of this
+					// group and adds nothing to what is being built.
+					if set := fr.byNode[callee]; set != nil {
 						yield(set)
 					}
 				}
@@ -246,35 +248,35 @@ func newFrontiers(rtaGraph *callgraph.Graph, followable *followableEdges, coverP
 		}
 		begin(root)
 		for len(frames) > 0 {
-			f := frames[len(frames)-1]
-			if f.next < len(f.edges) {
-				w := f.edges[f.next].Callee
+			f := &frames[len(frames)-1]
+			if f.next < len(f.callees) {
+				w := f.callees[f.next]
 				f.next++
 				if _, seen := order[w]; !seen {
-					begin(w)
-				} else if open[w] && order[w] < low[f.node] {
+					begin(w) // may reallocate frames; f is not used past here
+				} else if fr.byNode[w] == nil && order[w] < low[f.node] {
 					low[f.node] = order[w]
 				}
 				continue
 			}
+			node := f.node
 			frames = frames[:len(frames)-1]
-			if low[f.node] == order[f.node] {
+			if low[node] == order[node] {
 				var members []*callgraph.Node
 				for {
 					m := pending[len(pending)-1]
 					pending = pending[:len(pending)-1]
-					open[m] = false
 					members = append(members, m)
-					if m == f.node {
+					if m == node {
 						break
 					}
 				}
 				settle(members)
 			}
 			if len(frames) > 0 {
-				parent := frames[len(frames)-1]
-				if low[f.node] < low[parent.node] {
-					low[parent.node] = low[f.node]
+				parent := frames[len(frames)-1].node
+				if low[node] < low[parent] {
+					low[parent] = low[node]
 				}
 			}
 		}
@@ -285,13 +287,13 @@ func newFrontiers(rtaGraph *callgraph.Graph, followable *followableEdges, coverP
 
 // depsFrom returns the frontier of n's followable callees, sorted — the
 // per-function value stored in the suppDeps map.
-func (fr *frontiers) depsFrom(n *callgraph.Node, followable *followableEdges) []string {
+func (fr *frontiers) depsFrom(n *callgraph.Node, followable *followableCallees) []string {
 	var (
 		only     *frontierSet
 		distinct int
 	)
-	for _, e := range followable.from(n) {
-		set := fr.byNode[e.Callee]
+	for _, callee := range followable.from(n) {
+		set := fr.byNode[callee]
 		if set == nil || set == fr.empty {
 			continue
 		}
@@ -309,8 +311,8 @@ func (fr *frontiers) depsFrom(n *callgraph.Node, followable *followableEdges) []
 		return fr.ci.decode(only.bits)
 	default:
 		union := make([]uint64, fr.ci.words)
-		for _, e := range followable.from(n) {
-			if set := fr.byNode[e.Callee]; set != nil {
+		for _, callee := range followable.from(n) {
+			if set := fr.byNode[callee]; set != nil {
 				for i := range set.bits {
 					union[i] |= set.bits[i]
 				}

--- a/internal/cover/frontier_test.go
+++ b/internal/cover/frontier_test.go
@@ -1,0 +1,375 @@
+package cover
+
+import (
+	"fmt"
+	"go/types"
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+
+	"golang.org/x/tools/go/callgraph"
+	"golang.org/x/tools/go/ssa"
+)
+
+// The tests below build call graphs out of bare *ssa.Function values: the
+// dependency analysis only reads a function's package (and its Origin, which
+// is nil for a non-instantiated function), so a function needs nothing more
+// than a package and a signature for String() to work. Each function gets its
+// own package so that names stay distinct.
+
+const (
+	testCoverPkgPrefix = "example.com/app/cover"
+	testOtherPkgPrefix = "example.com/dep/other"
+)
+
+func newTestFunc(pkgPath string) *ssa.Function {
+	return &ssa.Function{
+		Signature: types.NewSignatureType(nil, nil, nil, nil, nil, false),
+		Pkg:       &ssa.Package{Pkg: types.NewPackage(pkgPath, "p")},
+	}
+}
+
+// testGraph is a call graph built from a compact description of its nodes.
+type testGraph struct {
+	graph       *callgraph.Graph
+	nodes       map[string]*callgraph.Node
+	coverPkgSet map[string]struct{}
+}
+
+// newTestGraph creates one node per key of edges. A key starting with "cover"
+// is a coverage-target function; "runtime", "http" and "grpc" prefixes place
+// the function in the corresponding cut-off package; anything else is an
+// ordinary dependency function. Edges carry no call site, so every edge is
+// followable.
+func newTestGraph(edges map[string][]string) *testGraph {
+	names := make([]string, 0, len(edges))
+	for name := range edges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	tg := &testGraph{
+		nodes:       make(map[string]*callgraph.Node, len(names)),
+		coverPkgSet: make(map[string]struct{}),
+	}
+	fns := make(map[string]*ssa.Function, len(names))
+	for _, name := range names {
+		var pkgPath string
+		switch {
+		case hasPrefix(name, "cover"):
+			pkgPath = testCoverPkgPrefix + "/" + name
+			tg.coverPkgSet[pkgPath] = struct{}{}
+		case hasPrefix(name, "runtime"):
+			pkgPath = "runtime/" + name
+		case hasPrefix(name, "http"):
+			pkgPath = "net/http"
+		case hasPrefix(name, "grpc"):
+			pkgPath = "google.golang.org/grpc/" + name
+		default:
+			pkgPath = testOtherPkgPrefix + "/" + name
+		}
+		fns[name] = newTestFunc(pkgPath)
+	}
+	tg.graph = callgraph.New(fns[names[0]])
+	for _, name := range names {
+		tg.nodes[name] = tg.graph.CreateNode(fns[name])
+	}
+	for _, name := range names {
+		for _, callee := range edges[name] {
+			callgraph.AddEdge(tg.nodes[name], nil, tg.nodes[callee])
+		}
+	}
+	return tg
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func (tg *testGraph) coverName(name string) string {
+	return normalizeFuncName(tg.nodes[name].Func)
+}
+
+// emptyVTAGraph stands in for a VTA graph when every edge is static (or, as in
+// these tests, has no site) and needs no confirmation.
+func emptyVTAGraph() *callgraph.Graph {
+	return &callgraph.Graph{Nodes: make(map[*ssa.Function]*callgraph.Node)}
+}
+
+// referenceDeps is the per-root walk the frontier computation replaces: it
+// explores from n's followable callees, records each coverage target it
+// reaches first and stops there, and is cut off at the excluded packages.
+// Kept as the executable definition of what a frontier is.
+func referenceDeps(coverPkgSet map[string]struct{}, n *callgraph.Node, followable *followableCallees) []string {
+	depMap := make(map[string]struct{})
+	seen := make(map[*callgraph.Node]struct{})
+	var walk func(*callgraph.Node)
+	walk = func(n *callgraph.Node) {
+		fn := n.Func
+		if fn != nil && funcCoverPkgPath(fn, coverPkgSet) != "" {
+			depMap[normalizeFuncName(fn)] = struct{}{}
+			return
+		}
+		path := resolvePkgPath(fn)
+		if isRuntimePackage(path) || isHTTPPackage(path) || isGRPCGoPackage(path) {
+			return
+		}
+		for _, callee := range followable.from(n) {
+			if _, ok := seen[callee]; ok {
+				continue
+			}
+			seen[callee] = struct{}{}
+			walk(callee)
+		}
+	}
+	for _, callee := range followable.from(n) {
+		if _, ok := seen[callee]; ok {
+			continue
+		}
+		seen[callee] = struct{}{}
+		walk(callee)
+	}
+	deps := make([]string, 0, len(depMap))
+	for dep := range depMap {
+		deps = append(deps, dep)
+	}
+	sort.Strings(deps)
+	return deps
+}
+
+func TestFrontiersDeps(t *testing.T) {
+	tests := []struct {
+		name  string
+		edges map[string][]string
+		want  map[string][]string // root -> expected cover deps (by node name)
+	}{
+		{
+			// A ⇄ B, and only A also reaches the target. Caching on first visit
+			// would settle B while A is still open and record nothing for B.
+			name: "cycle where one member alone reaches the target",
+			edges: map[string][]string{
+				"coverRoot": {"a"},
+				"a":         {"b", "coverY"},
+				"b":         {"a"},
+				"coverY":    {},
+			},
+			want: map[string][]string{
+				"coverRoot": {"coverY"},
+				"a":         {"coverY"},
+				"b":         {"coverY"},
+			},
+		},
+		{
+			// The root is a coverage target inside its own cycle: it appears
+			// in its own dependency list, as the walk stops at it.
+			name: "root reached through its own callees",
+			edges: map[string][]string{
+				"coverRoot": {"a"},
+				"a":         {"coverRoot", "coverZ"},
+				"coverZ":    {},
+			},
+			want: map[string][]string{
+				"coverRoot": {"coverRoot", "coverZ"},
+				"a":         {"coverRoot", "coverZ"},
+			},
+		},
+		{
+			// A coverage target is the boundary: what lies beyond it belongs to
+			// its own frontier, not to its callers'.
+			name: "walk stops at a coverage target",
+			edges: map[string][]string{
+				"coverRoot": {"coverMid"},
+				"coverMid":  {"coverFar"},
+				"coverFar":  {},
+			},
+			want: map[string][]string{
+				"coverRoot": {"coverMid"},
+				"coverMid":  {"coverFar"},
+				"coverFar":  {},
+			},
+		},
+		{
+			// Cut-off packages contribute nothing and hide what they call, but
+			// a root in such a package still has its own callees expanded.
+			name: "cut-off packages",
+			edges: map[string][]string{
+				"coverRoot":   {"runtimeA", "httpA", "grpcA", "b"},
+				"runtimeA":    {"coverHidden"},
+				"httpA":       {"coverHidden"},
+				"grpcA":       {"coverHidden"},
+				"b":           {"coverSeen"},
+				"coverHidden": {},
+				"coverSeen":   {},
+			},
+			want: map[string][]string{
+				"coverRoot": {"coverSeen"},
+				"runtimeA":  {"coverHidden"},
+			},
+		},
+		{
+			// Two cycles chained: the inner group's frontier is decided before
+			// the outer group's, and both see the target.
+			name: "nested cycles",
+			edges: map[string][]string{
+				"coverRoot": {"a"},
+				"a":         {"b"},
+				"b":         {"a", "c"},
+				"c":         {"d"},
+				"d":         {"c", "coverT"},
+				"coverT":    {},
+			},
+			want: map[string][]string{
+				"coverRoot": {"coverT"},
+				"a":         {"coverT"},
+				"c":         {"coverT"},
+			},
+		},
+		{
+			name: "self loop with no target",
+			edges: map[string][]string{
+				"coverRoot": {"a"},
+				"a":         {"a"},
+			},
+			want: map[string][]string{
+				"coverRoot": {},
+				"a":         {},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tg := newTestGraph(tt.edges)
+			followable := newFollowableCallees(tg.graph, emptyVTAGraph())
+			fr := newFrontiers(tg.graph, followable, tg.coverPkgSet)
+			for root, wantNames := range tt.want {
+				want := make([]string, 0, len(wantNames))
+				for _, name := range wantNames {
+					want = append(want, tg.coverName(name))
+				}
+				sort.Strings(want)
+				got := fr.depsFrom(tg.nodes[root], followable)
+				if got == nil {
+					t.Fatalf("%s: depsFrom returned nil; want a non-nil slice", root)
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("%s: deps = %v, want %v", root, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestFrontiersMatchReferenceWalk checks the shared, group-based computation
+// against the per-root walk on random graphs dense in cycles.
+func TestFrontiersMatchReferenceWalk(t *testing.T) {
+	for seed := int64(0); seed < 500; seed++ {
+		r := rand.New(rand.NewSource(seed))
+		numNodes := 1 + r.Intn(40)
+		edges := make(map[string][]string, numNodes)
+		names := make([]string, numNodes)
+		for i := range names {
+			var kind string
+			switch r.Intn(10) {
+			case 0, 1, 2:
+				kind = "cover"
+			case 3:
+				kind = "runtime"
+			case 4:
+				kind = "http"
+			case 5:
+				kind = "grpc"
+			default:
+				kind = "fn"
+			}
+			names[i] = fmt.Sprintf("%s%d", kind, i)
+		}
+		density := r.Intn(12) + 1
+		for _, name := range names {
+			for j, k := 0, r.Intn(density); j < k; j++ {
+				edges[name] = append(edges[name], names[r.Intn(numNodes)])
+			}
+			if edges[name] == nil {
+				edges[name] = []string{}
+			}
+		}
+
+		tg := newTestGraph(edges)
+		followable := newFollowableCallees(tg.graph, emptyVTAGraph())
+		fr := newFrontiers(tg.graph, followable, tg.coverPkgSet)
+		for name, n := range tg.nodes {
+			want := referenceDeps(tg.coverPkgSet, n, followable)
+			got := fr.depsFrom(n, followable)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("seed %d, node %s: deps = %v, want %v", seed, name, got, want)
+			}
+		}
+	}
+}
+
+func TestFollowableCalleesDedupesParallelEdges(t *testing.T) {
+	tg := newTestGraph(map[string][]string{
+		"coverRoot": {"a", "a", "b", "a"},
+		"a":         {},
+		"b":         {},
+	})
+	followable := newFollowableCallees(tg.graph, emptyVTAGraph())
+	got := followable.from(tg.nodes["coverRoot"])
+	if len(got) != 2 {
+		t.Fatalf("from(coverRoot) = %d callees, want 2 distinct", len(got))
+	}
+	if got[0] != tg.nodes["a"] || got[1] != tg.nodes["b"] {
+		t.Errorf("from(coverRoot) = %v, want [a b] in first-seen order", got)
+	}
+	if got := followable.from(tg.nodes["a"]); got != nil {
+		t.Errorf("from(a) = %v, want nil for a node without out-edges", got)
+	}
+}
+
+// dynamicSite is a call site whose callee is not statically known, so the
+// edge policy asks the VTA graph about it.
+func dynamicSite() ssa.CallInstruction {
+	return &ssa.Call{Call: ssa.CallCommon{Value: &ssa.Parameter{}}}
+}
+
+// staticSite is a call site that names its callee directly.
+func staticSite(callee *ssa.Function) ssa.CallInstruction {
+	return &ssa.Call{Call: ssa.CallCommon{Value: callee}}
+}
+
+func TestFollowableCalleesConfirmsDynamicEdgesPerCaller(t *testing.T) {
+	caller := newTestFunc(testCoverPkgPrefix + "/caller")
+	other := newTestFunc(testCoverPkgPrefix + "/other")
+	static := newTestFunc(testOtherPkgPrefix + "/static")
+	confirmed := newTestFunc(testOtherPkgPrefix + "/confirmed")
+	rejected := newTestFunc(testOtherPkgPrefix + "/rejected")
+	reflected := newTestFunc(testOtherPkgPrefix + "/reflected")
+
+	site := dynamicSite()
+
+	rta := callgraph.New(caller)
+	callerNode := rta.CreateNode(caller)
+	otherNode := rta.CreateNode(other)
+	callgraph.AddEdge(callerNode, staticSite(static), rta.CreateNode(static))
+	callgraph.AddEdge(callerNode, site, rta.CreateNode(confirmed))
+	callgraph.AddEdge(callerNode, site, rta.CreateNode(rejected))
+	callgraph.AddEdge(callerNode, nil, rta.CreateNode(reflected))
+	// other makes the same kind of dynamic call, but has no VTA node, so
+	// nothing confirms its edge.
+	callgraph.AddEdge(otherNode, dynamicSite(), rta.Nodes[confirmed])
+
+	vta := emptyVTAGraph()
+	vtaCaller := vta.CreateNode(caller)
+	callgraph.AddEdge(vtaCaller, site, vta.CreateNode(confirmed))
+
+	followable := newFollowableCallees(rta, vta)
+
+	got := followable.from(callerNode)
+	want := []*callgraph.Node{rta.Nodes[static], rta.Nodes[confirmed], rta.Nodes[reflected]}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("from(caller) = %v, want static, confirmed and site-less edges kept and the unconfirmed one dropped", got)
+	}
+	if got := followable.from(otherNode); got != nil {
+		t.Errorf("from(other) = %v, want nil: no VTA node for the caller", got)
+	}
+}

--- a/internal/cover/frontier_test.go
+++ b/internal/cover/frontier_test.go
@@ -2,6 +2,7 @@ package cover
 
 import (
 	"fmt"
+	"go/token"
 	"go/types"
 	"math/rand"
 	"reflect"
@@ -307,6 +308,126 @@ func TestFrontiersMatchReferenceWalk(t *testing.T) {
 	}
 }
 
+// followEdgeLinear is the edge policy stated independently of the lookup
+// structure the code under test builds: it scans the VTA out-edges of the
+// edge's own caller. Used as the oracle for per-caller confirmation.
+func followEdgeLinear(vtaGraph *callgraph.Graph, e *callgraph.Edge) bool {
+	if followedWithoutVTA(e.Site, e.Callee.Func) {
+		return true
+	}
+	caller := vtaGraph.Nodes[e.Caller.Func]
+	if caller == nil {
+		return false
+	}
+	for _, ve := range caller.Out {
+		if ve.Site == e.Site && ve.Callee.Func == e.Callee.Func {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFollowableCalleesMatchesEdgePolicy builds random graphs whose call sites
+// are owned by their caller, the way rta and vta both record them, and checks
+// the per-caller confirmation against a linear scan of the caller's VTA
+// out-edges. The frontier results are checked against the reference walk on
+// the same graphs, so the dynamic-call path is covered end to end.
+func TestFollowableCalleesMatchesEdgePolicy(t *testing.T) {
+	for seed := int64(0); seed < 300; seed++ {
+		r := rand.New(rand.NewSource(seed))
+		numNodes := 1 + r.Intn(25)
+
+		fns := make([]*ssa.Function, numNodes)
+		coverPkgSet := make(map[string]struct{})
+		for i := range fns {
+			var pkgPath string
+			switch r.Intn(8) {
+			case 0, 1:
+				pkgPath = fmt.Sprintf("%s/c%d", testCoverPkgPrefix, i)
+				coverPkgSet[pkgPath] = struct{}{}
+			case 2:
+				pkgPath = fmt.Sprintf("runtime/r%d", i)
+			case 3:
+				pkgPath = "net/http"
+			case 4:
+				pkgPath = fmt.Sprintf("google.golang.org/grpc/g%d", i)
+			default:
+				pkgPath = fmt.Sprintf("%s/d%d", testOtherPkgPrefix, i)
+			}
+			fns[i] = newTestFunc(pkgPath)
+		}
+
+		rtaGraph := callgraph.New(fns[0])
+		nodes := make([]*callgraph.Node, numNodes)
+		for i, fn := range fns {
+			nodes[i] = rtaGraph.CreateNode(fn)
+		}
+
+		// Sites are pooled per caller and shared between that caller's edges,
+		// the way RTA fans one dynamic call site out to many callees.
+		type callPair struct {
+			site   ssa.CallInstruction
+			callee *ssa.Function
+		}
+		pairs := make(map[int][]callPair, numNodes)
+		for i := range nodes {
+			pool := make([]ssa.CallInstruction, 0, 3)
+			for p, n := 0, 1+r.Intn(3); p < n; p++ {
+				pool = append(pool, randomSite(r, fns[r.Intn(numNodes)]))
+			}
+			for e, n := 0, r.Intn(7); e < n; e++ {
+				site := pool[r.Intn(len(pool))]
+				callee := fns[r.Intn(numNodes)]
+				callgraph.AddEdge(nodes[i], site, rtaGraph.Nodes[callee])
+				pairs[i] = append(pairs[i], callPair{site: site, callee: callee})
+			}
+		}
+
+		// A VTA graph recorded the way vta does: every edge of a caller carries
+		// a site belonging to that same caller. Some callers are absent, some
+		// pairs are unconfirmed, and some confirmations are for pairs RTA never
+		// proposes.
+		vtaGraph := emptyVTAGraph()
+		for i := range nodes {
+			if r.Intn(5) == 0 {
+				continue
+			}
+			vtaCaller := vtaGraph.CreateNode(fns[i])
+			for _, p := range pairs[i] {
+				if r.Intn(2) == 0 {
+					continue
+				}
+				callgraph.AddEdge(vtaCaller, p.site, vtaGraph.CreateNode(p.callee))
+			}
+			if len(pairs[i]) > 0 && r.Intn(3) == 0 {
+				callgraph.AddEdge(vtaCaller, pairs[i][0].site, vtaGraph.CreateNode(fns[r.Intn(numNodes)]))
+			}
+		}
+
+		followable := newFollowableCallees(rtaGraph, vtaGraph)
+		fr := newFrontiers(rtaGraph, followable, coverPkgSet)
+
+		for i, n := range nodes {
+			var want []*callgraph.Node
+			kept := make(map[*callgraph.Node]bool, len(n.Out))
+			for _, e := range n.Out {
+				if !followEdgeLinear(vtaGraph, e) || kept[e.Callee] {
+					continue
+				}
+				kept[e.Callee] = true
+				want = append(want, e.Callee)
+			}
+			if got := followable.from(n); !reflect.DeepEqual(got, want) {
+				t.Fatalf("seed %d, node %d: followable callees = %v, want %v", seed, i, got, want)
+			}
+			wantDeps := referenceDeps(coverPkgSet, n, followable)
+			if got := fr.depsFrom(n, followable); !reflect.DeepEqual(got, wantDeps) {
+				t.Fatalf("seed %d, node %d: deps = %v, want %v", seed, i, got, wantDeps)
+			}
+		}
+	}
+}
+
 func TestFollowableCalleesDedupesParallelEdges(t *testing.T) {
 	tg := newTestGraph(map[string][]string{
 		"coverRoot": {"a", "a", "b", "a"},
@@ -335,6 +456,28 @@ func dynamicSite() ssa.CallInstruction {
 // staticSite is a call site that names its callee directly.
 func staticSite(callee *ssa.Function) ssa.CallInstruction {
 	return &ssa.Call{Call: ssa.CallCommon{Value: callee}}
+}
+
+// invokeSite is an interface method call. Its callee here is never an
+// instantiated generic, so the policy asks the VTA graph about it.
+func invokeSite() ssa.CallInstruction {
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	method := types.NewFunc(token.NoPos, types.NewPackage("example.com/iface", "iface"), "M", sig)
+	return &ssa.Call{Call: ssa.CallCommon{Value: &ssa.Parameter{}, Method: method}}
+}
+
+// randomSite picks one of the call-site shapes the policy distinguishes.
+func randomSite(r *rand.Rand, staticCallee *ssa.Function) ssa.CallInstruction {
+	switch r.Intn(4) {
+	case 0:
+		return nil // a reflect edge, which RTA records without a site
+	case 1:
+		return staticSite(staticCallee)
+	case 2:
+		return dynamicSite()
+	default:
+		return invokeSite()
+	}
 }
 
 func TestFollowableCalleesConfirmsDynamicEdgesPerCaller(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-ups to #56 and #57, addressing the review points on both.

- **Per-caller VTA confirmation instead of a whole-graph index.** A call site belongs to exactly one function, and both graphs key their nodes by the same `*ssa.Function`, so the VTA node of an RTA edge's caller already holds every `(site, callee)` pair the policy can ask about for that edge. `vtaConfirmedEdges` builds that set for one caller at a time; a function whose calls are all static allocates nothing.
- **Deduplicated callees per node.** `followableCallees` stores the distinct followable callee nodes instead of the followable edges. The traversal only steps to nodes, and RTA records one edge per call site, so per-site duplicates no longer get re-walked in `settle` and `depsFrom`.
- **Simpler component bookkeeping.** `groupOf` and `open` are gone: a node's frontier is assigned the moment its group settles, so "frontier still nil" already identifies both an open node and an in-group callee. This also removes the collision between an unset `groupOf` entry (zero value) and group id 0, which was only safe by an invariant of the traversal.
- **Loud failure on a missing bit.** `notExpanded` panics if a coverage target has no bit in the frontier index rather than silently recording bit 0, a different function, as the dependency.

The edge policy and the frontier semantics are unchanged.

## Why the per-caller lookup is sound

Every RTA edge with a site records that site's own function as the caller: static edges are added as `addEdge(f, instr, ...)` for an instruction of `f`, and dynamic and invoke edges as `addEdge(site.Parent(), site, ...)`. The one edge whose caller is unrelated to the site is the `reflect.Value.Call` edge, and RTA gives it no site at all (`var site ssa.CallInstruction = nil // can't find actual call site`), which the policy resolves before any lookup. On the VTA side, `constrct` adds every edge of a caller `f` from `calls(f)`, the call instructions in `f`'s own blocks. So restricting the lookup to the edge's caller cannot lose a confirmation.

## Verification that the output is unchanged

- **Real program, byte for byte.** Building `go-yaml` through `cmd/ycat` with `-coverpkg=github.com/goccy/go-yaml/...` on isolated build caches, the supplementary dependency map is identical between `main` and this branch: 221 functions, 542 dependency entries, same SHA-256.
- **Every testdata program.** Same comparison across all testdata programs: identical in each.
- **Randomized, against the previous implementation.** 800 random call graphs whose call sites are pooled per caller and shared between edges (nil, static, dynamic and invoke shapes), paired with VTA graphs that confirm some pairs, omit some callers entirely and carry pairs RTA never proposes. Both the surviving callees and the dependency lists match `main`'s global index plus per-root walk on every node of every graph.
- **Determinism.** Repeating the whole computation on one graph 60 times gives identical output, so the map iteration order in the two constructors does not reach the result.
- `make lint`: 0 issues. `go test ./...` including e2e: pass.

`frontier_test.go` carries the parts of the above that belong in the tree: the cycle shape that first-visit caching gets wrong (A ⇄ B where only A reaches the target), a root inside its own cycle, the coverage-target boundary, cut-off packages, nested cycles, callee deduplication, per-caller confirmation, and two randomized comparisons against a reference per-root walk, one of which drives the dynamic-call path with a VTA graph. Injecting three deliberate faults (never confirming a dynamic edge, dropping the deduplication, and confirming against an arbitrary caller) fails these tests.

## Memory: measured, and less one-sided than it looks

Measured on the RTA and VTA graphs for `./cmd/tobari` (10,967 nodes, 73,045 edges, 53,352 edges surviving the policy):

| | main | this branch |
|---|---|---|
| whole-graph VTA index | 15,290 entries | none |
| largest confirmation set held at once | 15,290 entries | 288 entries |
| nodes aliasing `n.Out` | 10,323 | 0 |
| nodes with an allocated slice | 644 | 8,508 |
| resident total | ~0.5 MiB | ~0.5 MiB |

So on a graph this shape the change is memory-neutral, not a reduction. `main` aliased `n.Out` for the 94% of nodes where nothing was pruned, and switching from edges to callees gives that up; what the branch saves on the index it spends on per-node slices and the deduplication map. The win grows with dynamic-dispatch fan-out, which is what makes the index large in the first place, so the picture on the service in #56 should be better than this one, but I cannot measure that here.

What does improve regardless of shape: the largest structure held at one time drops from the whole index to one caller's confirmations, and the traversal walks 39,795 distinct callees instead of 53,352 edges, 25% fewer steps in the loops #57 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
