### PR TITLE
Let VTA resolve initial callees lazily instead of a full CHA graph

### DIFF
--- a/internal/cover/deps.go
+++ b/internal/cover/deps.go
@@ -85,7 +85,6 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/callgraph"
-	"golang.org/x/tools/go/callgraph/cha"
 	"golang.org/x/tools/go/callgraph/rta"
 	"golang.org/x/tools/go/callgraph/vta"
 	"golang.org/x/tools/go/packages"
@@ -527,7 +526,13 @@ func CreateMainDeps(mainSourceFiles []string, isTestMode bool, testPkgCfg *Packa
 	for fn := range rtaResult.Reachable {
 		vtaFuncs[fn] = true
 	}
-	vtaGraph := vta.CallGraph(vtaFuncs, cha.CallGraph(prog))
+	// The initial call graph VTA refines is left to vta.CallGraph (nil):
+	// it then resolves candidates with a lazy class-hierarchy lookup over
+	// vtaFuncs, keyed by signature and method id and memoized per interface
+	// method, instead of a cha.CallGraph built eagerly for every function in
+	// the program and searched linearly per call site. Candidates outside
+	// vtaFuncs are unreachable by RTA, so the same edges are confirmed.
+	vtaGraph := vta.CallGraph(vtaFuncs, nil)
 
 	followable := newFollowableCallees(graph, vtaGraph)
 	frontierSets := newFrontiers(graph, followable, coverPkgSet)


### PR DESCRIPTION
## Problem

`vta.CallGraph` is handed `cha.CallGraph(prog)` as its initial call graph. That graph is built eagerly for every function in the program, and VTA then searches it linearly per call site: `makeCalleesFunc` scans the caller node's `Out` edges for a matching `Site` on every lookup, once while building the propagation graph and again while constructing the final graph for dynamic calls. The whole CHA graph is dropped as soon as `vta.CallGraph` returns.

After #56, #57 and #59 the dependency extraction is cheap, so on a large service most of the remaining analysis time sits in VTA and in the allocation and GC churn of building graphs that are immediately discarded. The eager CHA graph is one of those.

## Change

Pass `nil` instead. `vta.CallGraph` then uses `chautil.LazyCallees` over the functions it analyzes (`vtaFuncs`, the RTA-reachable set): functions are indexed by signature, methods by method id, and the set of implementations of each interface method is memoized. No graph is materialized and no per-site linear scan happens.

One-line change plus a comment; the edge policy (`followEdge`) and everything downstream are untouched.

## Why the output is unchanged

The lazy lookup resolves candidates among `vtaFuncs` only, while the eager graph covered every function in the program. The functions this drops are not RTA-reachable, so any type flow through them was through code RTA already considers dead; `followEdge` only ever confirms RTA edges, so the confirmed set cannot grow, and it does not shrink because every candidate that could confirm an RTA edge is itself RTA-reachable and therefore in `vtaFuncs`. If a difference ever appeared it would be a pruned edge through unreachable code — more precise, not less — but none appeared in any measurement below.

## Result

On the same service as #56/#57 (2,963 coverage-target functions, no `-exclude-analysis`, cold build cache, macOS arm64 / 10 CPU / 32 GB), built on v0.12.2:

- Instrumented build: **572s → 394s** (-31%).
- System time: 423s → 109s, with page reclaims down from 43M to 16M — the churn of allocating and releasing the eager graph is gone along with its CPU.
- Supplementary dependency map: **byte-for-byte identical** (86,317,818 bytes, same SHA-256 as the map produced without this change).
- Peak RSS unchanged (~11–13 GB either way; the peak is set by RTA/VTA graph construction, not by CHA).

On a second, smaller service (dozens of coverage-target functions), built on v0.12.2 with and without this change:

- Supplementary dependency map byte-for-byte identical (553,173 bytes, same SHA-256).
- Both binaries were deployed and the same scenario suite was run against each; the resulting tobari cover reports have identical `metadata` (`files`, `entry`, `all` — 1,637 blocks) and identical per-scenario counts. The only difference was two runtime hit counts in `allcounts` for handlers exercised by readiness probes.

`go test ./...` including the e2e tests passes; `make lint` reports 0 issues.
