### PR TITLE
Bump golang.org/x/tools to v0.49.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/goccy/tobari
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	golang.org/x/mod v0.30.0
-	golang.org/x/tools v0.39.0
+	golang.org/x/mod v0.39.0
+	golang.org/x/tools v0.49.0
 )
 
-require golang.org/x/sync v0.18.0 // indirect
+require golang.org/x/sync v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-golang.org/x/mod v0.30.0 h1:fDEXFVZ/fmCKProc/yAXXUijritrDzahmwwefnjoPFk=
-golang.org/x/mod v0.30.0/go.mod h1:lAsf5O2EvJeSFMiBxXDki7sCgAxEUcZHXoXMKT4GJKc=
-golang.org/x/sync v0.18.0 h1:kr88TuHDroi+UVf+0hZnirlk8o8T+4MrK6mr60WkH/I=
-golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/tools v0.39.0 h1:ik4ho21kwuQln40uelmciQPp9SipgNDdrafrYA4TmQQ=
-golang.org/x/tools v0.39.0/go.mod h1:JnefbkDPyD8UU2kI5fuf8ZX4/yUeh9W877ZeBONxUqQ=
+golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
+golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=

--- a/testdata/concurrentquery/go.mod
+++ b/testdata/concurrentquery/go.mod
@@ -1,6 +1,6 @@
 module example.com/concurrentquery
 
-go 1.24.0
+go 1.25.0
 
 require github.com/goccy/tobari v0.0.0
 


### PR DESCRIPTION
## Summary

x/tools v0.39.0's `go/ssa` builder does not handle Go 1.27's new embedded-field struct literal syntax (golang/go#78553). A keyed literal that names a field promoted from an embedded struct never matches the builder's direct-fields loop in `compLit`, so the `*ast.KeyValueExpr` is never unwrapped and reaches `expr0`'s exhaustive type switch, which panics with `unexpected expr: *ast.KeyValueExpr`.

This hits any program built for `GOOS=linux` with a Go 1.27+ toolchain, because the standard library's `internal/poll/splice_linux.go` uses exactly this syntax. Any tobari user instrumenting such a program hits this panic during `CreateMainDeps`'s whole-program SSA analysis, unrelated to their own code.

x/tools fixed this in commit `8e51a5fb6` ("go/ssa: support direct references to embedded fields in struct lit"), landing in v0.45.0. This bumps past that to the latest release, v0.49.0, at the time of writing.

## Verification

- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass (two pre-existing test failures unrelated to this change were confirmed to also fail identically on unmodified `main`, caused by an unusually long/nested checkout path in my environment producing an extra embedded file in `TestEmbedCode`/`TestExtract`; not introduced by this bump).
- Built a minimal standalone program that imports `golang.org/x/net`'s `http2.Server` (which transitively pulls in `internal/poll/splice_linux.go`) and ran the same `packages.Load` -> `ssautil.AllPackages` -> `.Build()` sequence tobari's `CreateMainDeps` uses. With `GOOS=linux`:
  - x/tools v0.39.0 (before this bump): panics with the exact same trace, 100% reproducible across multiple runs.
  - x/tools v0.49.0 (after this bump): builds all 198 packages cleanly, 0 panics, across multiple runs.
- `go mod tidy` also bumped `testdata/concurrentquery`'s `go` directive to 1.25.0 to stay consistent with the root module (it replaces `github.com/goccy/tobari` with the local root module, whose `go` directive also moved to 1.25.0 as part of this bump).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, two pre-existing unrelated failures confirmed present on unmodified main)
- [x] Minimal repro confirms the panic before the bump and its absence after